### PR TITLE
feat: add TrafficLight & TagChipToggle components and update AppColors

### DIFF
--- a/healthy_scanner/lib/component/tag_chip_toggle.dart
+++ b/healthy_scanner/lib/component/tag_chip_toggle.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart'; 
+
+class TagChipToggle extends StatefulWidget {
+  final String label;
+  final bool initialSelected;
+  final Function(bool)? onChanged;
+
+  const TagChipToggle({
+    super.key,
+    required this.label,
+    this.initialSelected = false,
+    this.onChanged,
+  });
+
+  @override
+  State<TagChipToggle> createState() => _TagChipToggleState();
+}
+
+class _TagChipToggleState extends State<TagChipToggle> {
+  late bool _isSelected;
+
+  @override
+  void initState() {
+    super.initState();
+    _isSelected = widget.initialSelected;
+  }
+
+  void _toggleSelection() {
+    setState(() {
+      _isSelected = !_isSelected;
+    });
+    widget.onChanged?.call(_isSelected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor =
+        _isSelected ? AppColors.peachRed : AppColors.staticWhite;
+    final textColor =
+        _isSelected ? AppColors.mainRed : AppColors.brownGray;
+
+    return GestureDetector(
+      onTap: _toggleSelection,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 4),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(17),
+          border: Border.all(
+            color: _isSelected ? Colors.transparent : AppColors.softGray,
+            width: 1,
+          ),
+        ),
+        child: Text(
+          widget.label,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: textColor,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/healthy_scanner/lib/component/traffic_light.dart
+++ b/healthy_scanner/lib/component/traffic_light.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart'; // 경로에 맞게 수정하세요
+
+enum TrafficLightState { red, yellow, green }
+
+class TrafficLight extends StatelessWidget {
+  final TrafficLightState state;
+
+  const TrafficLight({
+    super.key,
+    required this.state,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildLight(AppColors.mainRed, state == TrafficLightState.red),
+        const SizedBox(width: 4),
+        _buildLight(AppColors.kakaoYellow, state == TrafficLightState.yellow),
+        const SizedBox(width: 4),
+        _buildLight(AppColors.mainGreen, state == TrafficLightState.green),
+      ],
+    );
+  }
+
+  Widget _buildLight(Color color, bool isActive) {
+    final double size = isActive ? 15 : 7;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}

--- a/healthy_scanner/lib/main.dart
+++ b/healthy_scanner/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:healthy_scanner/theme/app_theme.dart';
 import 'package:healthy_scanner/theme/theme_extensions.dart';
 import 'package:healthy_scanner/component/bottombutton.dart';
 import 'package:healthy_scanner/foodcard.dart';
+import 'package:healthy_scanner/component/tag_chip_toggle.dart';
+import 'package:healthy_scanner/component/traffic_light.dart';
 
 void main() {
   runApp(const MyApp());
@@ -55,7 +57,34 @@ class _MyHomePageState extends State<MyHomePage> {
                   // 카드 눌렸을 때 액션 추가: 상세 페이지 등으로 이동
                 },
               ),
+              
             ),
+            const SizedBox(height: 30),
+
+            // ✅ 질환 칩 버튼 테스트
+            const Text('🔹 질환 태그 테스트', style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: const [
+                TagChipToggle(label: '고혈압'),
+                SizedBox(width: 12),
+                TagChipToggle(label: '당뇨병', initialSelected: true),
+              ],
+            ),
+
+            const SizedBox(height: 40),
+
+            // ✅ 신호등 테스트
+            const Text('🔸 신호등 테스트', style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 12),
+            const TrafficLight(state: TrafficLightState.red),
+            const SizedBox(height: 12),
+            const TrafficLight(state: TrafficLightState.yellow),
+            const SizedBox(height: 12),
+            const TrafficLight(state: TrafficLightState.green),
+
+
             Text(
               'Caption1 Medium',
               style: context.caption1Medium,
@@ -80,6 +109,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ],
         ),
       ),
+      
       bottomNavigationBar: SafeArea(
         minimum: const EdgeInsets.fromLTRB(15, 0, 15, 10),
         child: BottomButton(

--- a/healthy_scanner/lib/theme/app_colors.dart
+++ b/healthy_scanner/lib/theme/app_colors.dart
@@ -19,4 +19,7 @@ class AppColors {
   static const mainRed = Color(0xFFFF5938);
   static const salmonRed = Color(0xFFFFAA99);
   static const peachRed = Color(0xFFFFD4CC);
+  static const kakaoYellow = Color(0xFFFEE500);
+  static const mainGreen = Color(0xFF86CE02);
+
 }


### PR DESCRIPTION
## 작업 설명
- 신호등(트래픽 라이트) UI 컴포넌트 추가
- 질환 태그(TagChipToggle) 컴포넌트 추가
- AppColors에 maingreen, kakaoYellow 색상 수정 및 추가 반영


## 구현 내용
- lib/component/traffic_light.dart 생성 (신호등 컴포넌트)
- lib/component/tag_chip_toggle.dart 생성 (칩 컴포넌트)
- lib/theme/app_colors.dart 수정

## 스크린샷

| 질환/알레르기 태그, 신호등 테스트 |
<img width="464" height="1019" alt="image" src="https://github.com/user-attachments/assets/55dd6f20-22cb-433b-8ddd-b7a276e15c60" />


## 고민한 내용
- 해당 신호등 컴포넌트를 카드에 추가하면 될 것 같습니다 이제~

## 추후 작업할 내용
<!-- 미완료된 작업이나 새로운 이슈가 있다면 간략히 적어주세요. -->

## 연결된 이슈
- Resolved: #11 
