### PR TITLE
feat: 온보딩 및 수정/마이페이지 관련 API 연결

### DIFF
--- a/healthy_scanner/.vscode/settings.json
+++ b/healthy_scanner/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "java.configuration.updateBuildConfiguration": "automatic"
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "CodeGPT.apiKey": "OpenRouter"
 }

--- a/healthy_scanner/ios/Runner.xcodeproj/project.pbxproj
+++ b/healthy_scanner/ios/Runner.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LNZ4277YX9;
+				DEVELOPMENT_TEAM = PB259G2F38;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -672,7 +672,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LNZ4277YX9;
+				DEVELOPMENT_TEAM = PB259G2F38;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -680,7 +680,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -696,7 +696,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = LNZ4277YX9;
+				DEVELOPMENT_TEAM = PB259G2F38;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -704,7 +704,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/healthy_scanner/ios/Runner/Info.plist
+++ b/healthy_scanner/ios/Runner/Info.plist
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Healthy Scanner</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>healthy_scanner</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>$(DEVELOPMENT_LANGUAGE)</string>
-		<key>CFBundleDisplayName</key>
-		<string>Healthy Scanner</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>healthy_scanner</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
-		<key>LSRequiresIPhoneOS</key>
+		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
-		<key>UIMainStoryboardFile</key>
-		<string>Main</string>
-		<key>UISupportedInterfaceOrientations</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationLandscapeLeft</string>
-			<string>UIInterfaceOrientationLandscapeRight</string>
-		</array>
-		<key>UISupportedInterfaceOrientations~ipad</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationPortraitUpsideDown</string>
-			<string>UIInterfaceOrientationLandscapeLeft</string>
-			<string>UIInterfaceOrientationLandscapeRight</string>
-		</array>
-		<key>CADisableMinimumFrameDurationOnPhone</key>
-		<true/>
-		<key>UIApplicationSupportsIndirectInputEvents</key>
-		<true/>
-		<key>UIStatusBarHidden</key>
-		<false/>
-    	<key>NSCameraUsageDescription</key>
-    	<string>식품을 스캔하기 위해 카메라를 사용합니다.</string>
-		<key>NSPhotoLibraryUsageDescription</key>
-		<string>기기에 저장된 사진을 불러오기 위해 사용합니다.</string>
-		<key>NSAppTransportSecurity</key>
-		<dict>
-			<key>NSAllowsArbitraryLoads</key>
-			<true/>
-		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>식품을 스캔하기 위해 카메라를 사용합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>기기에 저장된 사진을 불러오기 위해 사용합니다.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIStatusBarHidden</key>
+	<false/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
 </plist>

--- a/healthy_scanner/lib/constants/onboarding_constants.dart
+++ b/healthy_scanner/lib/constants/onboarding_constants.dart
@@ -1,0 +1,118 @@
+class OnboardingConstants {
+  OnboardingConstants._();
+
+  static const String defaultDietLabel = '일반식';
+  static const String noDiseaseLabel = '건강 질환이 없어요';
+  static const String noAllergyLabel = '없어요';
+
+  static const Map<String, String> habitMap = {
+    '일반식': 'regular',
+    '생선 채식': 'pescatarian',
+    '유제품 허용 채식': 'lactoVegetarian',
+    '달걀 허용 채식': 'ovoVegetarian',
+    '채식': 'vegan',
+  };
+
+  static const Map<String, String> conditionMap = {
+    '고혈압': 'hypertension',
+    '간질환': 'liverDisease',
+    '통풍': 'gout',
+    '당뇨병': 'diabetes',
+    '고지혈증': 'hyperlipidemia',
+    '신장질환': 'kidneyDisease',
+    '갑상선질환': 'thyroidDisease',
+  };
+
+  static const Map<String, String> allergyMap = {
+    '갑각류': 'crustacean',
+    '밀': 'wheat',
+    '조개류': 'shellfish',
+    '새우': 'shrimp',
+    '유제품': 'dairy',
+    '소고기': 'beef',
+    '견과류': 'nut',
+    '복숭아': 'peach',
+    '계란': 'egg',
+    '사과': 'apple',
+    '파인애플': 'pineapple',
+    '생선': 'fish',
+    '대두(콩)': 'soy',
+    '땅콩': 'peanut',
+  };
+
+  static const Map<String, String> _conditionCodeToLabel = {
+    'hypertension': '고혈압',
+    'liverDisease': '간질환',
+    'gout': '통풍',
+    'diabetes': '당뇨병',
+    'hyperlipidemia': '고지혈증',
+    'kidneyDisease': '신장질환',
+    'thyroidDisease': '갑상선질환',
+  };
+
+  static const Map<String, String> _allergyCodeToLabel = {
+    'crustacean': '갑각류',
+    'wheat': '밀',
+    'shellfish': '조개류',
+    'shrimp': '새우',
+    'dairy': '유제품',
+    'beef': '소고기',
+    'nut': '견과류',
+    'peanut': '견과류',
+    'peach': '복숭아',
+    'egg': '계란',
+    'apple': '사과',
+    'pineapple': '파인애플',
+    'fish': '생선',
+    'soy': '대두(콩)',
+  };
+
+  static List<String> mapHabit(String? selectedHabit) {
+    final key = (selectedHabit == null || selectedHabit.isEmpty)
+        ? defaultDietLabel
+        : selectedHabit;
+    final resolved = habitMap[key];
+    if (resolved == null) return [];
+    return [resolved];
+  }
+
+  static String? habitCodeToLabel(String? code) {
+    if (code == null || code.isEmpty) return null;
+    for (final entry in habitMap.entries) {
+      if (entry.value == code) return entry.key;
+    }
+    return null;
+  }
+
+  static List<String> mapConditions(List<String> selectedConditions) {
+    return selectedConditions
+        .where((condition) => condition != noDiseaseLabel)
+        .map((condition) => conditionMap[condition])
+        .whereType<String>()
+        .toList();
+  }
+
+  static List<String> conditionCodesToLabels(List<String>? codes) {
+    if (codes == null) return [];
+    return codes
+        .map((code) => _conditionCodeToLabel[code])
+        .whereType<String>()
+        .toList();
+  }
+
+  static List<String> mapAllergies(List<String> selectedAllergies) {
+    return selectedAllergies
+        .where((allergy) => allergy != noAllergyLabel)
+        .map((allergy) => allergyMap[allergy])
+        .whereType<String>()
+        .toList();
+  }
+
+  static List<String> allergyCodesToLabels(List<String>? codes) {
+    if (codes == null) return [];
+    return codes
+        .map((code) => _allergyCodeToLabel[code])
+        .whereType<String>()
+        .toList();
+  }
+}

--- a/healthy_scanner/lib/controller/auth_controller.dart
+++ b/healthy_scanner/lib/controller/auth_controller.dart
@@ -44,7 +44,7 @@ class AuthController extends GetxController {
 
     if (appAccess.value != null && appAccess.value!.isNotEmpty) {
       debugPrint("🔐 Saved AccessToken found → Auto login");
-      nav.goToHome();
+      nav.goToOnboardingAgree();
     }
   }
 
@@ -92,7 +92,7 @@ class AuthController extends GetxController {
           key: "kakao_refresh_expires_in", value: refreshExpiresIn.toString());
     }
 
-    nav.goToHome();
+    nav.goToOnboardingAgree();
   }
 
   /// ----------------------------------------------------------

--- a/healthy_scanner/lib/controller/mypage_controller.dart
+++ b/healthy_scanner/lib/controller/mypage_controller.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:healthy_scanner/constants/onboarding_constants.dart';
+import 'package:healthy_scanner/controller/auth_controller.dart';
+import 'package:healthy_scanner/data/api_service.dart';
+import 'package:healthy_scanner/data/my_page_info_response.dart';
+
+class MyPageController extends GetxController {
+  MyPageController(this._api);
+
+  final ApiService _api;
+  late final AuthController _auth = Get.find<AuthController>();
+
+  final profileInfo = Rxn<MyPageInfoResponse>();
+  final isLoading = false.obs;
+  final errorMessage = RxnString();
+  final isUpdatingHabit = false.obs;
+  final currentHabitKorean = OnboardingConstants.defaultDietLabel.obs;
+  final currentConditionsKorean = <String>[].obs;
+  final currentAllergiesKorean = <String>[].obs;
+  final isUpdatingConditions = false.obs;
+  final isUpdatingAllergies = false.obs;
+
+  Worker? _jwtWorker;
+
+  @override
+  void onInit() {
+    super.onInit();
+
+    _jwtWorker = ever<String?>(_auth.appAccess, (jwt) {
+      if (jwt == null || jwt.isEmpty) {
+        profileInfo.value = null;
+        errorMessage.value = '로그인이 필요합니다.';
+      } else {
+        fetchMyPageInfo();
+      }
+    });
+
+    final jwt = _auth.appAccess.value;
+    if (jwt != null && jwt.isNotEmpty) {
+      fetchMyPageInfo();
+    }
+  }
+
+  @override
+  void onClose() {
+    _jwtWorker?.dispose();
+    super.onClose();
+  }
+
+  Future<void> fetchMyPageInfo() async {
+    final token = _auth.appAccess.value;
+    if (token == null || token.isEmpty) {
+      errorMessage.value = '로그인이 필요합니다.';
+      return;
+    }
+
+    isLoading.value = true;
+    errorMessage.value = null;
+
+    try {
+      final info = await _api.fetchMyPageInfo(jwt: token);
+      profileInfo.value = info;
+      final habitLabel = OnboardingConstants.habitCodeToLabel(info.habit);
+      if (habitLabel != null && habitLabel.isNotEmpty) {
+        currentHabitKorean.value = habitLabel;
+      }
+      currentConditionsKorean.assignAll(
+        OnboardingConstants.conditionCodesToLabels(info.conditions),
+      );
+      currentAllergiesKorean.assignAll(
+        OnboardingConstants.allergyCodesToLabels(info.allergies),
+      );
+    } catch (e) {
+      debugPrint('❌ [MyPage] fetch failed: $e');
+      errorMessage.value = '마이페이지 정보를 불러오지 못했어요.';
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<bool> updateHabit(String koreanHabit) async {
+    if (isUpdatingHabit.value) return false;
+
+    final token = _auth.appAccess.value;
+    if (token == null || token.isEmpty) {
+      Get.snackbar(
+        '로그인이 필요합니다',
+        '다시 로그인해 주세요.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return false;
+    }
+
+    isUpdatingHabit.value = true;
+    try {
+      await _api.updateHabit(jwt: token, koreanHabit: koreanHabit);
+      currentHabitKorean.value = koreanHabit;
+      Get.snackbar(
+        '저장 완료',
+        '식습관 정보가 업데이트되었어요.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return true;
+    } catch (e) {
+      debugPrint('❌ [MyPage] update habit failed: $e');
+      Get.snackbar(
+        '저장에 실패했어요',
+        '네트워크 상태를 확인한 뒤 다시 시도해 주세요.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return false;
+    } finally {
+      isUpdatingHabit.value = false;
+    }
+  }
+
+  Future<bool> updateConditions(List<String> koreanConditions) async {
+    if (isUpdatingConditions.value) return false;
+    final token = _auth.appAccess.value;
+    if (token == null || token.isEmpty) {
+      return false;
+    }
+
+    isUpdatingConditions.value = true;
+    try {
+      await _api.updateConditions(
+        jwt: token,
+        koreanConditions: koreanConditions,
+      );
+      currentConditionsKorean.assignAll(koreanConditions);
+      return true;
+    } catch (e) {
+      debugPrint('❌ [MyPage] update conditions failed: $e');
+      return false;
+    } finally {
+      isUpdatingConditions.value = false;
+    }
+  }
+
+  Future<bool> updateAllergies(List<String> koreanAllergies) async {
+    if (isUpdatingAllergies.value) return false;
+    final token = _auth.appAccess.value;
+    if (token == null || token.isEmpty) {
+      return false;
+    }
+
+    isUpdatingAllergies.value = true;
+    try {
+      await _api.updateAllergies(
+        jwt: token,
+        koreanAllergies: koreanAllergies,
+      );
+      currentAllergiesKorean.assignAll(koreanAllergies);
+      return true;
+    } catch (e) {
+      debugPrint('❌ [MyPage] update allergies failed: $e');
+      return false;
+    } finally {
+      isUpdatingAllergies.value = false;
+    }
+  }
+}

--- a/healthy_scanner/lib/data/api_service.dart
+++ b/healthy_scanner/lib/data/api_service.dart
@@ -1,0 +1,207 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:healthy_scanner/controller/auth_controller.dart';
+import 'package:healthy_scanner/controller/navigation_controller.dart';
+import 'package:healthy_scanner/constants/onboarding_constants.dart';
+import 'package:healthy_scanner/data/my_page_info_response.dart';
+import 'package:http/http.dart' as http;
+
+class ApiService {
+  ApiService({
+    required this.baseUrl,
+    http.Client? client,
+  }) : _client = client ?? http.Client();
+
+  final String baseUrl;
+  final http.Client _client;
+
+  Future<MyPageInfoResponse> fetchMyPageInfo({
+    required String jwt,
+  }) async {
+    final uri = Uri.parse('$baseUrl/v1/myPage/summary');
+    final response = await _client.get(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $jwt',
+        'Accept': 'application/json',
+      },
+    );
+
+    _handleUnauthorized(response);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'MyPage summary failed: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return MyPageInfoResponse.fromJson(data);
+  }
+
+  Future<void> postOnboardingProfile({
+    required String jwt,
+    required List<String> habits,
+    required List<String> conditions,
+    required List<String> allergies,
+  }) async {
+    final uri = Uri.parse('$baseUrl/v1/users/profile');
+    final payload = jsonEncode({
+      'habits': habits,
+      'conditions': conditions,
+      'allergies': allergies,
+    });
+
+    try {
+      final response = await _client.post(
+        uri,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $jwt',
+        },
+        body: payload,
+      );
+
+      _handleUnauthorized(response);
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception(
+          'Onboarding profile API failed: ${response.statusCode} ${response.body}',
+        );
+      }
+
+      debugPrint('✅ Onboarding profile uploaded');
+    } catch (e) {
+      debugPrint('❌ postOnboardingProfile error: $e');
+      rethrow;
+    }
+  }
+
+  Future<HabitUpdateResponse> updateHabit({
+    required String jwt,
+    required String koreanHabit,
+  }) async {
+    final englishHabit = OnboardingConstants.habitMap[koreanHabit];
+    if (englishHabit == null) {
+      throw Exception('Unsupported habit: $koreanHabit');
+    }
+
+    final uri = Uri.parse('$baseUrl/v1/me/habits');
+    final response = await _client.patch(
+      uri,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $jwt',
+      },
+      body: jsonEncode({'habit': englishHabit}),
+    );
+
+    _handleUnauthorized(response);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'Habit update failed: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return HabitUpdateResponse.fromJson(data);
+  }
+
+  Future<void> updateConditions({
+    required String jwt,
+    required List<String> koreanConditions,
+  }) async {
+    final conditionCodes = OnboardingConstants.mapConditions(koreanConditions);
+    final headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $jwt',
+    };
+    final body = jsonEncode({'conditions': conditionCodes});
+    final response = await _patchWithFallback(
+      primaryPath: '/v1/me/conditions',
+      fallbackPath: '/v1/me/condition',
+      headers: headers,
+      body: body,
+    );
+
+    _handleUnauthorized(response);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'Condition update failed: ${response.statusCode} ${response.body}',
+      );
+    }
+  }
+
+  Future<void> updateAllergies({
+    required String jwt,
+    required List<String> koreanAllergies,
+  }) async {
+    final allergyCodes = OnboardingConstants.mapAllergies(koreanAllergies);
+    final headers = {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $jwt',
+    };
+    final body = jsonEncode({'allergies': allergyCodes});
+    final response = await _patchWithFallback(
+      primaryPath: '/v1/me/allergies',
+      fallbackPath: '/v1/me/allergy',
+      headers: headers,
+      body: body,
+    );
+
+    _handleUnauthorized(response);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'Allergy update failed: ${response.statusCode} ${response.body}',
+      );
+    }
+  }
+
+  void _handleUnauthorized(http.Response response) {
+    if (response.statusCode != 401) return;
+
+    debugPrint('🔒 Token expired or unauthorized. Forcing logout.');
+    final auth = Get.isRegistered<AuthController>()
+        ? Get.find<AuthController>()
+        : null;
+
+    if (auth != null) {
+      auth.logout();
+    } else {
+      final nav = Get.isRegistered<NavigationController>()
+          ? Get.find<NavigationController>()
+          : null;
+      nav?.goToLogin();
+    }
+
+    throw Exception('Unauthorized request: ${response.body}');
+  }
+
+  Future<http.Response> _patchWithFallback({
+    required String primaryPath,
+    String? fallbackPath,
+    required Map<String, String> headers,
+    required String body,
+  }) async {
+    final primary = await _client.patch(
+      Uri.parse('$baseUrl$primaryPath'),
+      headers: headers,
+      body: body,
+    );
+
+    if (primary.statusCode == 404 && fallbackPath != null) {
+      debugPrint('⚠️ $primaryPath not found, trying $fallbackPath');
+      return _client.patch(
+        Uri.parse('$baseUrl$fallbackPath'),
+        headers: headers,
+        body: body,
+      );
+    }
+
+    return primary;
+  }
+}

--- a/healthy_scanner/lib/data/my_page_info_response.dart
+++ b/healthy_scanner/lib/data/my_page_info_response.dart
@@ -1,0 +1,97 @@
+class MyPageInfoResponse {
+  const MyPageInfoResponse({
+    required this.name,
+    required this.scanCount,
+    required this.profileImageUrl,
+    this.habit,
+    this.conditions = const [],
+    this.allergies = const [],
+  });
+
+  final String name;
+  final int scanCount;
+  final String profileImageUrl;
+  final String? habit;
+  final List<String> conditions;
+  final List<String> allergies;
+
+  factory MyPageInfoResponse.fromJson(Map<String, dynamic> json) {
+    final normalized = _extractUserPayload(json);
+    return MyPageInfoResponse(
+      name: _extractCleanString(normalized['name']) ?? '',
+      scanCount: (normalized['scan_count'] ?? 0) as int,
+      profileImageUrl:
+          _extractCleanString(normalized['profile_image_url']) ?? '',
+      habit: _extractPrimaryString(normalized['habit']),
+      conditions: _extractStringList(normalized['conditions']),
+      allergies: _extractStringList(normalized['allergies']),
+    );
+  }
+
+  static Map<String, dynamic> _extractUserPayload(
+    Map<String, dynamic> raw,
+  ) {
+    // NOTE: /v1/myPage/summary sometimes nests user metadata under `user`,
+    // but numeric stats(e.g., scan_count) stay on the root. We merge both maps
+    // so UI always sees a complete snapshot regardless of backend shape.
+    final merged = Map<String, dynamic>.from(raw);
+    final user = raw['user'];
+    if (user is Map<String, dynamic>) {
+      merged.addAll(user);
+    }
+    return merged;
+  }
+
+  static String? _extractCleanString(dynamic value) {
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty || trimmed.toLowerCase() == 'none') return null;
+      return trimmed;
+    }
+    return null;
+  }
+
+  static String? _extractPrimaryString(dynamic value) {
+    if (value is String) {
+      final clean = _extractCleanString(value);
+      if (clean != null) return clean;
+    }
+    if (value is List && value.isNotEmpty) {
+      final first = value.first;
+      if (first is String) return first;
+      return first?.toString();
+    }
+    return null;
+  }
+
+  static List<String> _extractStringList(dynamic value) {
+    if (value is List) {
+      return value
+          .map((e) => e?.toString())
+          .whereType<String>()
+          .toList();
+    }
+    if (value is String && value.isNotEmpty) {
+      return [value];
+    }
+    return [];
+  }
+}
+
+class HabitUpdateResponse {
+  const HabitUpdateResponse({
+    required this.habit,
+    required this.updatedAt,
+  });
+
+  final String habit;
+  final DateTime? updatedAt;
+
+  factory HabitUpdateResponse.fromJson(Map<String, dynamic> json) {
+    final updated = json['updated_at'] as String?;
+    return HabitUpdateResponse(
+      habit: (json['habit'] ?? '') as String,
+      updatedAt: updated != null ? DateTime.tryParse(updated) : null,
+    );
+  }
+}

--- a/healthy_scanner/lib/main.dart
+++ b/healthy_scanner/lib/main.dart
@@ -5,6 +5,8 @@ import 'controller/navigation_controller.dart';
 import 'controller/scan_controller.dart';
 import 'controller/auth_controller.dart';
 import 'controller/home_controller.dart';
+import 'controller/mypage_controller.dart';
+import 'data/api_service.dart';
 import 'data/home_api.dart';
 import 'core/app_secure_storage.dart';
 import 'core/api_client.dart';
@@ -19,6 +21,14 @@ void main() async {
   Get.put(NavigationController(), permanent: true);
   Get.put(AuthController(), permanent: true);
   Get.put(ScanController(), permanent: true);
+  Get.put(
+    ApiService(baseUrl: ApiClient.baseUrl),
+    permanent: true,
+  );
+  Get.put(
+    MyPageController(Get.find<ApiService>()),
+    permanent: true,
+  );
   Get.put(HomeController(HomeApi(baseUrl: 'https://healthy-scanner.com')));
 
   runApp(const MyApp());

--- a/healthy_scanner/lib/view/login/login_main_view.dart
+++ b/healthy_scanner/lib/view/login/login_main_view.dart
@@ -90,7 +90,7 @@ class LoginMainView extends StatelessWidget {
                     ),
                     onPressed: () {
                       // TODO: 네이버 로그인 API 연동 예정
-                      nav.goToHome(); // ✅ 임시로 홈으로 이동
+                      nav.goToOnboardingAgree(); // ✅ 임시로 온보딩으로 이동
                     },
                   ),
                   const SizedBox(height: 20),
@@ -100,8 +100,8 @@ class LoginMainView extends StatelessWidget {
                     behavior: HitTestBehavior.opaque,
                     onTap: () {
                       // TODO: 문의 페이지 연결 (예: 이메일, 피드백 폼 등)
-                      // 임시 개발용: 로그인 없이 홈으로 연결
-                      nav.goToHome();
+                      // 임시 개발용: 로그인 없이 온보딩으로 연결
+                      nav.goToOnboardingAgree();
                     },
                     child: Padding(
                       padding: const EdgeInsets.all(6),

--- a/healthy_scanner/lib/view/mypage/mypage_view.dart
+++ b/healthy_scanner/lib/view/mypage/mypage_view.dart
@@ -1,177 +1,229 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:healthy_scanner/controller/mypage_controller.dart';
 import '../../controller/navigation_controller.dart';
 import '../../controller/auth_controller.dart';
 import '../../theme/app_colors.dart';
 import '../../theme/app_typography.dart';
 
-class MyPageView extends StatelessWidget {
+class MyPageView extends GetView<MyPageController> {
   const MyPageView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.find<NavigationController>();
+    final nav = Get.find<NavigationController>();
+    final auth = Get.find<AuthController>();
 
     return Scaffold(
       backgroundColor: AppColors.backgroundGray,
       body: SafeArea(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // 🔹 뒤로가기 버튼
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: IconButton(
-                    icon: const Icon(Icons.arrow_back_ios_new,
-                        color: AppColors.cloudGray, size: 22),
-                    onPressed: controller.goBack,
-                  ),
-                ),
-                const SizedBox(height: 8),
+        child: Obx(() {
+          if (controller.isLoading.value) {
+            return const Center(
+              child: CircularProgressIndicator(color: AppColors.mainRed),
+            );
+          }
 
-                // 🔹 프로필 카드
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(20),
-                  decoration: BoxDecoration(
-                    color: AppColors.mainRed,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Row(
-                    children: [
-                      const CircleAvatar(
-                        radius: 30,
-                        backgroundColor: AppColors.warmGray,
-                        child: Icon(Icons.person,
-                            color: AppColors.staticWhite, size: 40),
+          final error = controller.errorMessage.value;
+          if (error != null) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      error,
+                      textAlign: TextAlign.center,
+                      style: AppTextStyles.bodyMedium.copyWith(
+                        color: AppColors.brownGray,
                       ),
-                      const SizedBox(width: 16),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: controller.fetchMyPageInfo,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.mainRed,
+                      ),
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          final info = controller.profileInfo.value;
+          final name =
+              (info?.name.isNotEmpty ?? false) ? info!.name : '건강한 한 끼';
+          final scanCount = info?.scanCount ?? 0;
+          final profileImage = info?.profileImageUrl ?? '';
+
+          return RefreshIndicator(
+            color: AppColors.mainRed,
+            onRefresh: controller.fetchMyPageInfo,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: IconButton(
+                        icon: const Icon(
+                          Icons.arrow_back_ios_new,
+                          color: AppColors.cloudGray,
+                          size: 22,
+                        ),
+                        onPressed: nav.goBack,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(20),
+                      decoration: BoxDecoration(
+                        color: AppColors.mainRed,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Row(
                         children: [
-                          Text(
-                            '김캡스',
-                            style: AppTextStyles.title2Medium.copyWith(
-                              color: AppColors.staticWhite,
-                            ),
+                          CircleAvatar(
+                            radius: 30,
+                            backgroundColor: AppColors.warmGray,
+                            backgroundImage: profileImage.isNotEmpty
+                                ? NetworkImage(profileImage)
+                                : null,
+                            child: profileImage.isEmpty
+                                ? const Icon(
+                                    Icons.person,
+                                    color: AppColors.staticWhite,
+                                    size: 40,
+                                  )
+                                : null,
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            '총 스캔 횟수 21회',
-                            style: AppTextStyles.footnote1Regular.copyWith(
-                              color: AppColors.staticWhite,
-                            ),
+                          const SizedBox(width: 16),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                name,
+                                style: AppTextStyles.title2Medium.copyWith(
+                                  color: AppColors.staticWhite,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                '총 스캔 횟수 $scanCount회',
+                                style: AppTextStyles.footnote1Regular.copyWith(
+                                  color: AppColors.staticWhite,
+                                ),
+                              ),
+                            ],
                           ),
                         ],
                       ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 24),
+                    ),
+                    const SizedBox(height: 24),
 
-                // 🔹 식습관 / 질환 / 알레르기 구역
-                Container(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  decoration: BoxDecoration(
-                    color: AppColors.staticWhite,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children: [
-                      _buildInfoItem(
-                        icon: Icons.local_florist_outlined,
-                        label: '식습관',
-                        onTap: controller.goToMyPageDietEdit,
+                    Container(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      decoration: BoxDecoration(
+                        color: AppColors.staticWhite,
+                        borderRadius: BorderRadius.circular(12),
                       ),
-                      _buildInfoItem(
-                        icon: Icons.medical_services_outlined,
-                        label: '건강 질환',
-                        onTap: controller.goToMyPageDiseaseEdit,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceAround,
+                        children: [
+                          _buildInfoItem(
+                            icon: Icons.local_florist_outlined,
+                            label: '식습관',
+                            onTap: nav.goToMyPageDietEdit,
+                          ),
+                          _buildInfoItem(
+                            icon: Icons.medical_services_outlined,
+                            label: '건강 질환',
+                            onTap: nav.goToMyPageDiseaseEdit,
+                          ),
+                          _buildInfoItem(
+                            icon: Icons.sentiment_neutral_outlined,
+                            label: '알레르기',
+                            onTap: nav.goToMyPageAllergyEdit,
+                          ),
+                        ],
                       ),
-                      _buildInfoItem(
-                        icon: Icons.sentiment_neutral_outlined,
-                        label: '알레르기',
-                        onTap: controller.goToMyPageAllergyEdit,
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 24),
+                    ),
+                    const SizedBox(height: 24),
 
-                // 🔹 설정 메뉴
-                Container(
-                  width: double.infinity,
-                  decoration: BoxDecoration(
-                    color: AppColors.staticWhite,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Column(
-                    children: [
-                      _buildSettingItem(
-                        label: '고객센터',
-                        onTap: () {
-                          // TODO: 고객센터 연결
-                        },
+                    Container(
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        color: AppColors.staticWhite,
+                        borderRadius: BorderRadius.circular(12),
                       ),
-                      _divider(),
-                      _buildSettingItem(
-                        label: '이용 약관',
-                        onTap: () {
-                          // TODO: WebView로 약관 연결
-                        },
-                      ),
-                      _divider(),
-                      _buildSettingItem(
-                        label: '개인정보 처리방침',
-                        onTap: () {
-                          // TODO: WebView로 개인정보 연결
-                        },
-                      ),
-                      _divider(),
-                      _buildSettingItem(
-                        label: '로그아웃',
-                        onTap: () => Get.find<AuthController>().logout(),
-                      ),
-                      _divider(),
-                      _buildSettingItem(
-                        label: '계정 탈퇴',
-                        onTap: () {
-                          Get.dialog(
-                            AlertDialog(
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              title: const Text('계정을 정말 탈퇴하시겠어요?'),
-                              content: const Text('탈퇴 후 데이터는 복구되지 않습니다.'),
-                              actions: [
-                                TextButton(
-                                  onPressed: () => Get.back(),
-                                  child: const Text('취소'),
+                      child: Column(
+                        children: [
+                          _buildSettingItem(
+                            label: '고객센터',
+                            onTap: () {},
+                          ),
+                          _divider(),
+                          _buildSettingItem(
+                            label: '이용 약관',
+                            onTap: () {},
+                          ),
+                          _divider(),
+                          _buildSettingItem(
+                            label: '개인정보 처리방침',
+                            onTap: () {},
+                          ),
+                          _divider(),
+                          _buildSettingItem(
+                            label: '로그아웃',
+                            onTap: auth.logout,
+                          ),
+                          _divider(),
+                          _buildSettingItem(
+                            label: '계정 탈퇴',
+                            onTap: () {
+                              Get.dialog(
+                                AlertDialog(
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  title: const Text('계정을 정말 탈퇴하시겠어요?'),
+                                  content:
+                                      const Text('탈퇴 후 데이터는 복구되지 않습니다.'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Get.back(),
+                                      child: const Text('취소'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () async {
+                                        Get.back();
+                                        await auth.withdrawAccount();
+                                      },
+                                      child: const Text('탈퇴'),
+                                    ),
+                                  ],
                                 ),
-                                TextButton(
-                                  onPressed: () async {
-                                    Get.back();
-                                    await Get.find<AuthController>()
-                                        .withdrawAccount();
-                                  },
-                                  child: const Text('탈퇴'),
-                                ),
-                              ],
-                            ),
-                          );
-                        },
+                              );
+                            },
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
-        ),
+          );
+        }),
       ),
     );
   }

--- a/healthy_scanner/lib/view/onboarding/onboarding_allergy_view.dart
+++ b/healthy_scanner/lib/view/onboarding/onboarding_allergy_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:healthy_scanner/constants/onboarding_constants.dart';
 import '../../controller/navigation_controller.dart';
 import '../../component/tag_chip_toggle.dart';
 import '../../component/bottom_button.dart';
@@ -24,7 +25,7 @@ class OnboardingAllergyView extends GetView<NavigationController> {
       '대두(콩)',
       '유제품',
       '소고기',
-      '없어요',
+      OnboardingConstants.noAllergyLabel,
     ];
 
     return Scaffold(
@@ -95,17 +96,22 @@ class OnboardingAllergyView extends GetView<NavigationController> {
                             controller.selectedAllergies.contains(allergy);
 
                         return TagChipToggle(
+                          key: ValueKey(allergy),
                           label: allergy,
                           initialSelected: isSelected,
                           onChanged: (v) {
                             // ✅ '없어요' 선택 시 다른 알러지 해제
-                            if (allergy == '없어요' && v) {
+                            if (allergy ==
+                                    OnboardingConstants.noAllergyLabel &&
+                                v) {
                               controller.selectedAllergies.clear();
-                              controller.selectedAllergies.add('없어요');
+                              controller.selectedAllergies
+                                  .add(OnboardingConstants.noAllergyLabel);
                             } else {
                               if (controller.selectedAllergies
-                                  .contains('없어요')) {
-                                controller.selectedAllergies.remove('없어요');
+                                  .contains(OnboardingConstants.noAllergyLabel)) {
+                                controller.selectedAllergies
+                                    .remove(OnboardingConstants.noAllergyLabel);
                               }
                               if (v) {
                                 controller.selectedAllergies.add(allergy);

--- a/healthy_scanner/lib/view/onboarding/onboarding_complete_view.dart
+++ b/healthy_scanner/lib/view/onboarding/onboarding_complete_view.dart
@@ -76,10 +76,14 @@ class OnboardingCompleteView extends GetView<NavigationController> {
                   // 🔹 시작 버튼
                   Padding(
                     padding: const EdgeInsets.only(bottom: 24),
-                    child: BottomButton(
-                      text: '시작하기',
-                      onPressed: controller.finishOnboarding,
-                    ),
+                    child: Obx(() {
+                      final isLoading = controller.isSubmittingProfile.value;
+                      return BottomButton(
+                        text: isLoading ? '전송 중...' : '시작하기',
+                        isEnabled: !isLoading,
+                        onPressed: () => controller.submitOnboardingProfile(),
+                      );
+                    }),
                   ),
                 ],
               ),

--- a/healthy_scanner/lib/view/onboarding/onboarding_diet_view.dart
+++ b/healthy_scanner/lib/view/onboarding/onboarding_diet_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:healthy_scanner/constants/onboarding_constants.dart';
 import '../../component/bottom_button.dart';
 import '../../controller/navigation_controller.dart';
 import '../../theme/app_colors.dart';
@@ -13,8 +14,6 @@ class OnboardingDietView extends StatefulWidget {
 }
 
 class _OnboardingDietViewState extends State<OnboardingDietView> {
-  String selectedDiet = '일반식'; // ✅ 기본 선택값
-
   final List<String> dietOptions = [
     '일반식',
     '생선 채식',
@@ -22,6 +21,15 @@ class _OnboardingDietViewState extends State<OnboardingDietView> {
     '달걀 허용 채식',
     '채식',
   ];
+
+  @override
+  void initState() {
+    super.initState();
+    final controller = Get.find<NavigationController>();
+    if (controller.selectedDiet.isEmpty) {
+      controller.selectedDiet.value = OnboardingConstants.defaultDietLabel;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -87,36 +95,41 @@ class _OnboardingDietViewState extends State<OnboardingDietView> {
                     border: Border.all(color: AppColors.softGray),
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: DropdownButtonFormField<String>(
-                    initialValue: selectedDiet,
-                    icon: const Icon(
-                      Icons.keyboard_arrow_down,
-                      color: AppColors.charcoleGray,
-                    ),
-                    decoration: const InputDecoration(
-                      border: InputBorder.none,
-                    ),
-                    dropdownColor: AppColors.staticWhite,
-                    style: AppTextStyles.footnote1Medium.copyWith(
-                      color: AppColors.stoneGray,
-                    ),
-                    items: dietOptions.map((option) {
-                      return DropdownMenuItem<String>(
-                        value: option,
-                        child: Text(
-                          option,
-                          style: AppTextStyles.footnote1Medium.copyWith(
-                            color: AppColors.charcoleGray,
+                  child: Obx(() {
+                    final selectedValue = controller.selectedDiet.value.isEmpty
+                        ? OnboardingConstants.defaultDietLabel
+                        : controller.selectedDiet.value;
+                    return DropdownButtonFormField<String>(
+                      key: ValueKey(selectedValue),
+                      initialValue: selectedValue,
+                      icon: const Icon(
+                        Icons.keyboard_arrow_down,
+                        color: AppColors.charcoleGray,
+                      ),
+                      decoration: const InputDecoration(
+                        border: InputBorder.none,
+                      ),
+                      dropdownColor: AppColors.staticWhite,
+                      style: AppTextStyles.footnote1Medium.copyWith(
+                        color: AppColors.stoneGray,
+                      ),
+                      items: dietOptions.map((option) {
+                        return DropdownMenuItem<String>(
+                          value: option,
+                          child: Text(
+                            option,
+                            style: AppTextStyles.footnote1Medium.copyWith(
+                              color: AppColors.charcoleGray,
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
-                    onChanged: (value) {
-                      setState(() {
-                        selectedDiet = value!;
-                      });
-                    },
-                  ),
+                        );
+                      }).toList(),
+                      onChanged: (value) {
+                        if (value == null) return;
+                        controller.selectedDiet.value = value;
+                      },
+                    );
+                  }),
                 ),
               ),
 
@@ -125,10 +138,12 @@ class _OnboardingDietViewState extends State<OnboardingDietView> {
               // 🔹 다음 버튼
               Padding(
                 padding: const EdgeInsets.only(bottom: 24),
-                child: BottomButton(
-                  text: '다음',
-                  isEnabled: true,
-                  onPressed: controller.goToOnboardingDisease,
+                child: Obx(
+                  () => BottomButton(
+                    text: '다음',
+                    isEnabled: controller.isDietValid,
+                    onPressed: controller.goToOnboardingDisease,
+                  ),
                 ),
               ),
             ],

--- a/healthy_scanner/lib/view/onboarding/onboarding_disease_view.dart
+++ b/healthy_scanner/lib/view/onboarding/onboarding_disease_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:healthy_scanner/constants/onboarding_constants.dart';
 import '../../component/bottom_button.dart';
 import '../../component/tag_chip_toggle.dart';
 import '../../controller/navigation_controller.dart';
@@ -14,11 +15,12 @@ class OnboardingDiseaseView extends StatefulWidget {
 }
 
 class _OnboardingDiseaseViewState extends State<OnboardingDiseaseView> {
+  late final NavigationController controller;
   final RxSet<String> selectedDiseases = <String>{}.obs;
 
   // ✅ 질병 목록 (순서 및 누락 보완)
   final List<String> diseaseOptions = [
-    '건강 질환이 없어요',
+    OnboardingConstants.noDiseaseLabel,
     '고혈압',
     '간질환',
     '통풍',
@@ -29,9 +31,20 @@ class _OnboardingDiseaseViewState extends State<OnboardingDiseaseView> {
   ];
 
   @override
-  Widget build(BuildContext context) {
-    final controller = Get.find<NavigationController>();
+  void initState() {
+    super.initState();
+    controller = Get.find<NavigationController>();
+    if (controller.selectedDiseases.isNotEmpty) {
+      selectedDiseases.addAll(controller.selectedDiseases);
+    }
+  }
 
+  void _syncSelection() {
+    controller.selectedDiseases.assignAll(selectedDiseases.toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFFAFAFA), // ✅ 배경색 적용
       body: SafeArea(
@@ -97,25 +110,28 @@ class _OnboardingDiseaseViewState extends State<OnboardingDiseaseView> {
                       children: diseaseOptions.map((disease) {
                         final isSelected = selectedDiseases.contains(disease);
                         return TagChipToggle(
+                          key: ValueKey(disease),
                           label: disease,
                           initialSelected: isSelected,
                           onChanged: (selected) {
                             if (selected) {
                               // ✅ ‘건강 질환이 없어요’ 선택 시 나머지 전부 해제 후 단독 선택
-                              if (disease == '건강 질환이 없어요') {
+                              if (disease == OnboardingConstants.noDiseaseLabel) {
                                 selectedDiseases
                                   ..clear()
-                                  ..add('건강 질환이 없어요');
+                                  ..add(OnboardingConstants.noDiseaseLabel);
                               }
                               // ✅ 다른 질환 선택 시 ‘건강 질환이 없어요’ 해제
                               else {
-                                selectedDiseases.remove('건강 질환이 없어요');
+                                selectedDiseases
+                                    .remove(OnboardingConstants.noDiseaseLabel);
                                 selectedDiseases.add(disease);
                               }
                             } else {
                               // ✅ 다시 클릭 시 해당 질환만 해제
                               selectedDiseases.remove(disease);
                             }
+                            _syncSelection();
                           },
                         );
                       }).toList(),


### PR DESCRIPTION
## 작업 설명
- 온보딩과 마이페이지 프로필 API 전반을 연동
- 토큰 만료·예외 상황에 안전하게 대응하도록 전체 플로우를 정비
- MyPage 요약 API에서 내려오는 데이터를 기반으로 UI를 실시간 갱신하고, 편집 화면에서 다시 서버로 저장할 수 있는 양방향 흐름을 모두 구현

## 구현 내용
- MyPageController를 새로 만들어 요약 데이터 fetch, 편집 상태 관리, 세 가지 수정 API 호출을 담당하게 하고, MyPage 뷰/편집 화면들을 이 컨트롤러에 연결해 초기 선택값을 표시하고 저장 시 API를 호출하도록 구성
- 응답이 user 루트로 섞여오는 케이스를 흡수하도록 모델 파싱을 보완, None 같은 잘못된 URL 값을 걸러서 UI가 크래시하지 않도록 방어 로직을 넣었습니다
- 토큰 만료 시 전역적으로 로그아웃시키는 _handleUnauthorized를 ApiService에 추가하고, 조건/알레르리 PATCH는 단수/복수 URL을 모두 시도하도록 fallback 로직을 넣었습니다.



## 고민한 내용
- MyPage 응답 포맷이 상황에 따라 루트/user로 나뉘는 데다 habit이 배열로 내려오는 케이스도 있어, 모델에서 데이터를 정규화하고 역매핑까지 지원하는 방향으로 설계

- 편집 화면에서 “없어요”와 일반 칩이 동시에 선택되지 않도록 온보딩 로직을 재사용


## 연결된 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
- Resolved: 44
