### PR TITLE
[Feature] 식품 분석 상세 조회 API 연결

### DIFF
--- a/healthy_scanner/ios/Runner.xcodeproj/project.pbxproj
+++ b/healthy_scanner/ios/Runner.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = PB259G2F38;
+				DEVELOPMENT_TEAM = LNZ4277YX9;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.songhee.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -672,7 +672,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = PB259G2F38;
+				DEVELOPMENT_TEAM = LNZ4277YX9;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -680,7 +680,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.songhee.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -696,7 +696,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = PB259G2F38;
+				DEVELOPMENT_TEAM = LNZ4277YX9;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
@@ -704,7 +704,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.h1s2u.healthyScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.songhee.healthyScanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/healthy_scanner/lib/constants/onboarding_constants.dart
+++ b/healthy_scanner/lib/constants/onboarding_constants.dart
@@ -115,4 +115,14 @@ class OnboardingConstants {
         .whereType<String>()
         .toList();
   }
+
+  static String? conditionCodeToLabel(String? code) {
+    if (code == null || code.isEmpty) return null;
+    return _conditionCodeToLabel[code];
+  }
+
+  static String? allergyCodeToLabel(String? code) {
+    if (code == null || code.isEmpty) return null;
+    return _allergyCodeToLabel[code];
+  }
 }

--- a/healthy_scanner/lib/controller/analysis_result_controller.dart
+++ b/healthy_scanner/lib/controller/analysis_result_controller.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:healthy_scanner/core/api_client.dart';
+import 'package:healthy_scanner/data/scan_api.dart';
+import 'package:healthy_scanner/data/scan_history_detail_response.dart';
+
+class AnalysisResultController extends GetxController {
+  late final String scanId;
+
+  final RxBool isLoading = true.obs;
+  final RxnString error = RxnString();
+  final Rxn<ScanHistoryDetailResponse> detail =
+      Rxn<ScanHistoryDetailResponse>();
+
+  late final ScanApi _api = ScanApi(dioClient: ApiClient.dioClient);
+
+  @override
+  void onInit() {
+    super.onInit();
+    final args = Get.arguments as Map<String, dynamic>?;
+
+    scanId = (args?['scanId'] ?? '').toString();
+    if (scanId.isEmpty) {
+      isLoading.value = false;
+      error.value = 'scanId is missing';
+      return;
+    }
+
+    fetch();
+  }
+
+  Future<void> fetch() async {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      final res = await _api.getScanHistoryDetails(scanId: scanId);
+      detail.value = res;
+    } catch (e) {
+      debugPrint('❌ [AnalysisResultController] fetch failed: $e');
+      error.value = e.toString();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/healthy_scanner/lib/controller/archive_controller.dart
+++ b/healthy_scanner/lib/controller/archive_controller.dart
@@ -28,6 +28,7 @@ class ArchiveListController extends GetxController {
 
       final resolved = result.map((it) {
         return ScanHistoryItem(
+          scanId: it.scanId,
           name: it.name,
           category: it.category,
           summary: it.summary,

--- a/healthy_scanner/lib/controller/auth_controller.dart
+++ b/healthy_scanner/lib/controller/auth_controller.dart
@@ -19,6 +19,7 @@ class AuthController extends GetxController {
   final tokenType = RxnString();
   final expiresIn = RxnInt();
   final refreshExpiresIn = RxnInt();
+  final userId = RxnString();
 
   @override
   void onInit() {
@@ -34,6 +35,7 @@ class AuthController extends GetxController {
     final expiresInStr = await storage.read(key: "kakao_expires_in");
     final refreshExpiresInStr =
         await storage.read(key: "kakao_refresh_expires_in");
+    userId.value = await storage.read(key: "user_id");
 
     if (expiresInStr != null) {
       expiresIn.value = int.tryParse(expiresInStr);
@@ -44,7 +46,7 @@ class AuthController extends GetxController {
 
     if (appAccess.value != null && appAccess.value!.isNotEmpty) {
       debugPrint("🔐 Saved AccessToken found → Auto login");
-      nav.goToOnboardingAgree();
+      nav.routeAfterLogin();
     }
   }
 
@@ -63,6 +65,7 @@ class AuthController extends GetxController {
     required String appRefreshToken,
     required String kakaoAccessToken,
     required String kakaoRefreshToken,
+    required String userId,
     String? tokenType,
     int? expiresIn,
     int? refreshExpiresIn,
@@ -73,6 +76,7 @@ class AuthController extends GetxController {
     appAccess.value = appAccessToken;
     await storage.write(key: "jwt", value: appAccessToken);
     await storage.write(key: "app_refresh_token", value: appRefreshToken);
+    await storage.write(key: "user_id", value: userId);
     kakaoAccess.value = kakaoAccessToken;
     kakaoRefresh.value = kakaoRefreshToken;
     this.tokenType.value = tokenType;
@@ -92,7 +96,7 @@ class AuthController extends GetxController {
           key: "kakao_refresh_expires_in", value: refreshExpiresIn.toString());
     }
 
-    nav.goToOnboardingAgree();
+    nav.routeAfterLogin();
   }
 
   /// ----------------------------------------------------------

--- a/healthy_scanner/lib/controller/auth_controller.dart
+++ b/healthy_scanner/lib/controller/auth_controller.dart
@@ -158,9 +158,7 @@ class AuthController extends GetxController {
           key: "kakao_refresh_expires_in", value: refreshExpiresIn.toString());
     }
 
-// TODO: 최초가입자 온보딩으로 라우팅
-    // nav.routeAfterLogin();
-    nav.goToOnboardingAgree();
+    nav.routeAfterLogin();
   }
 
   /// ----------------------------------------------------------

--- a/healthy_scanner/lib/controller/auth_controller.dart
+++ b/healthy_scanner/lib/controller/auth_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:healthy_scanner/core/app_secure_storage.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:healthy_scanner/core/api_client.dart';
+import 'package:healthy_scanner/core/onboarding_store.dart';
 
 class AuthController extends GetxController {
   static String backendLoginURL =
@@ -159,9 +160,16 @@ class AuthController extends GetxController {
   /// 5) 계정 탈퇴(연동 해제)
   /// ----------------------------------------------------------
   Future<void> withdrawAccount() async {
+    final uid = userId.value;
+
     try {
       final res = await ApiClient.dioClient.delete("/auth/unlink");
       debugPrint("🗑️ Withdraw API ok: ${res.statusCode}, body=${res.data}");
+
+      if (uid != null && uid.isNotEmpty) {
+        await OnboardingStore.clear(userKey: uid);
+      }
+
       await logout();
     } catch (e) {
       debugPrint("❌ Withdraw API failed: $e");

--- a/healthy_scanner/lib/controller/auth_controller.dart
+++ b/healthy_scanner/lib/controller/auth_controller.dart
@@ -7,6 +7,9 @@ import 'package:healthy_scanner/core/app_secure_storage.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:healthy_scanner/core/api_client.dart';
 import 'package:healthy_scanner/core/onboarding_store.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:healthy_scanner/controller/home_controller.dart';
+import 'package:healthy_scanner/controller/scan_controller.dart';
 
 class AuthController extends GetxController {
   static String backendLoginURL =
@@ -185,6 +188,7 @@ class AuthController extends GetxController {
     await storage.delete(key: "kakao_token_type");
     await storage.delete(key: "kakao_expires_in");
     await storage.delete(key: "kakao_refresh_expires_in");
+    await storage.delete(key: "user_id");
 
     appAccess.value = null;
     kakaoAccess.value = null;
@@ -231,12 +235,39 @@ class AuthController extends GetxController {
         await OnboardingStore.clear(userKey: uid);
       }
 
+      await GetStorage().erase();
+      _resetPermanentControllers();
+
       await logout();
     } catch (e) {
       debugPrint("❌ Withdraw API failed: $e");
       Get.snackbar("계정 탈퇴 실패", "잠시 후 다시 시도해주세요.",
           snackPosition: SnackPosition.BOTTOM);
     }
+  }
+
+  void _resetPermanentControllers() {
+    if (Get.isRegistered<HomeController>()) {
+      Get.find<HomeController>().resetState();
+    }
+    if (Get.isRegistered<ScanController>()) {
+      Get.find<ScanController>().resetState();
+    }
+    if (Get.isRegistered<NavigationController>()) {
+      Get.find<NavigationController>().resetState();
+    }
+    // AuthController는 지금 this니까 바로 호출해도 됨
+    resetState();
+  }
+
+  void resetState() {
+    appAccess.value = null;
+    kakaoAccess.value = null;
+    kakaoRefresh.value = null;
+    tokenType.value = null;
+    expiresIn.value = null;
+    refreshExpiresIn.value = null;
+    userId.value = null;
   }
 
 // ----------------------------------------------------------

--- a/healthy_scanner/lib/controller/home_controller.dart
+++ b/healthy_scanner/lib/controller/home_controller.dart
@@ -41,6 +41,13 @@ class HomeController extends GetxController {
     super.onClose();
   }
 
+  void resetState() {
+    isLoading.value = false;
+    errorMessage.value = null;
+    todayScore.value = 0;
+    scanItems.clear();
+  }
+
   Future<void> fetchHome() async {
     isLoading.value = true;
     errorMessage.value = null;

--- a/healthy_scanner/lib/controller/home_controller.dart
+++ b/healthy_scanner/lib/controller/home_controller.dart
@@ -60,6 +60,7 @@ class HomeController extends GetxController {
 
       final normalized = res.scan.take(2).map((it) {
         return ScanItem(
+          scanId: it.scanId,
           name: it.name,
           category: it.category,
           riskLevel: it.riskLevel,

--- a/healthy_scanner/lib/controller/mypage_controller.dart
+++ b/healthy_scanner/lib/controller/mypage_controller.dart
@@ -31,15 +31,14 @@ class MyPageController extends GetxController {
       if (jwt == null || jwt.isEmpty) {
         profileInfo.value = null;
         errorMessage.value = '로그인이 필요합니다.';
-      } else {
-        fetchMyPageInfo();
       }
     });
+  }
 
-    final jwt = _auth.appAccess.value;
-    if (jwt != null && jwt.isNotEmpty) {
-      fetchMyPageInfo();
-    }
+  @override
+  void onReady() {
+    super.onReady();
+    fetchMyPageInfo();
   }
 
   @override
@@ -60,6 +59,14 @@ class MyPageController extends GetxController {
 
     try {
       final info = await _api.fetchMyPageInfo(jwt: token);
+
+      debugPrint('✅ [MyPage] fetch success raw response:');
+      debugPrint('👤 userName: ${info.name}');
+      debugPrint('📊 totalScanCount: ${info.scanCount}');
+      debugPrint('🍽 habit: ${info.habit}');
+      debugPrint('⚠️ conditions: ${info.conditions}');
+      debugPrint('🚫 allergies: ${info.allergies}');
+
       profileInfo.value = info;
       final habitLabel = OnboardingConstants.habitCodeToLabel(info.habit);
       if (habitLabel != null && habitLabel.isNotEmpty) {

--- a/healthy_scanner/lib/controller/navigation_controller.dart
+++ b/healthy_scanner/lib/controller/navigation_controller.dart
@@ -39,6 +39,17 @@ class NavigationController extends SuperController {
   @override
   void onHidden() {}
 
+  void resetState() {
+    agreedPolicy.value = false;
+    agreedService.value = false;
+
+    selectedDiet.value = '';
+    selectedDiseases.clear();
+    selectedAllergies.clear();
+
+    isSubmittingProfile.value = false;
+  }
+
   // ------------------------
   // 🔹 Route Observer Hook
   // ------------------------

--- a/healthy_scanner/lib/controller/navigation_controller.dart
+++ b/healthy_scanner/lib/controller/navigation_controller.dart
@@ -11,6 +11,7 @@ import 'package:healthy_scanner/controller/scan_controller.dart';
 import 'package:healthy_scanner/controller/home_controller.dart';
 import 'package:healthy_scanner/controller/mypage_controller.dart';
 import 'package:healthy_scanner/view/login/kakao_login_webview.dart';
+import 'package:healthy_scanner/core/onboarding_store.dart';
 
 /// 📍 모든 페이지 전환을 중앙에서 관리하는 컨트롤러
 class NavigationController extends SuperController {
@@ -115,16 +116,22 @@ class NavigationController extends SuperController {
         conditions: conditionPayload,
         allergies: allergyPayload,
       );
+
+      final auth = Get.find<AuthController>();
+      final userKey = auth.userId.value;
+      await OnboardingStore.setCompleted(true, userKey: userKey);
+
       if (Get.isRegistered<MyPageController>()) {
         final myPage = Get.find<MyPageController>();
         myPage.currentHabitKorean.value = selectedDiet.value;
         myPage.fetchMyPageInfo();
       }
+
       finishOnboarding();
     } catch (e) {
       debugPrint('❌ [ONBOARDING] submit failed: $e');
       Get.snackbar(
-        '저장에 실패했어요',
+        '등록에 실패했어요',
         '네트워크 상태를 확인한 뒤 다시 시도해 주세요.',
         snackPosition: SnackPosition.BOTTOM,
       );
@@ -241,5 +248,17 @@ class NavigationController extends SuperController {
         Get.find<HomeController>().fetchHome();
       }
     });
+  }
+
+  void routeAfterLogin() {
+    final auth = Get.find<AuthController>();
+    final userKey = auth.userId.value;
+    final completed = OnboardingStore.isCompleted(userKey: userKey);
+
+    if (completed) {
+      goToHome();
+    } else {
+      goToOnboardingAgree();
+    }
   }
 }

--- a/healthy_scanner/lib/controller/navigation_controller.dart
+++ b/healthy_scanner/lib/controller/navigation_controller.dart
@@ -195,8 +195,8 @@ class NavigationController extends SuperController {
         arguments: payload.toArgs(),
       );
 
-  /// ✅ 홈(로그인 등)으로 돌아가기
-  void backToHome() => Get.offAllNamed(AppRoutes.loginMain);
+  /// ✅ 로그인 화면으로 돌아가기
+  void backToLoginMain() => Get.offAllNamed(AppRoutes.loginMain);
 
   /// ✅ 홈 → 마이페이지
   void goToMyPage() => Get.toNamed(AppRoutes.myPage);
@@ -227,9 +227,19 @@ class NavigationController extends SuperController {
   }
 
   void goToAnalysisResult({required String scanId}) {
-    Get.offNamed(
-      AppRoutes.analysisResult,
-      arguments: {'scanId': scanId},
-    );
+    Get.offAllNamed(AppRoutes.home);
+
+    Future.microtask(() {
+      Get.toNamed(
+        AppRoutes.analysisResult,
+        arguments: {'scanId': scanId},
+      );
+    });
+
+    Future.microtask(() {
+      if (Get.isRegistered<HomeController>()) {
+        Get.find<HomeController>().fetchHome();
+      }
+    });
   }
 }

--- a/healthy_scanner/lib/controller/scan_controller.dart
+++ b/healthy_scanner/lib/controller/scan_controller.dart
@@ -130,6 +130,18 @@ class ScanController extends GetxController {
     super.onClose();
   }
 
+  void resetState() {
+    try {
+      cameraController?.dispose();
+    } catch (_) {}
+    cameraController = null;
+    initializeControllerFuture = null;
+
+    mode.value = ScanMode.ingredient;
+    isTakingPicture.value = false;
+    lastImagePath.value = null;
+  }
+
   /// 🔹 크롭된 이미지를 받아서 모드에 따라 분석 + 다음 화면 이동
   Future<void> handleCroppedImage(
     Uint8List imageBytes, {

--- a/healthy_scanner/lib/controller/splash_controller.dart
+++ b/healthy_scanner/lib/controller/splash_controller.dart
@@ -17,9 +17,7 @@ class SplashController extends GetxController {
 
     final ok = await _auth.bootstrapAutoLogin();
     if (ok) {
-      // TODO: 최초가입자 온보딩으로 라우팅
-      // _nav.routeAfterLogin();
-      _nav.goToOnboardingAgree();
+      _nav.routeAfterLogin();
     } else {
       _nav.goToLogin();
     }

--- a/healthy_scanner/lib/controller/splash_controller.dart
+++ b/healthy_scanner/lib/controller/splash_controller.dart
@@ -1,0 +1,27 @@
+import 'package:get/get.dart';
+import 'package:healthy_scanner/controller/auth_controller.dart';
+import 'package:healthy_scanner/controller/navigation_controller.dart';
+
+class SplashController extends GetxController {
+  final _auth = Get.find<AuthController>();
+  final _nav = Get.find<NavigationController>();
+
+  @override
+  void onReady() {
+    super.onReady();
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    await Future.delayed(const Duration(seconds: 1));
+
+    final ok = await _auth.bootstrapAutoLogin();
+    if (ok) {
+      // TODO: 최초가입자 온보딩으로 라우팅
+      // _nav.routeAfterLogin();
+      _nav.goToOnboardingAgree();
+    } else {
+      _nav.goToLogin();
+    }
+  }
+}

--- a/healthy_scanner/lib/core/api_client.dart
+++ b/healthy_scanner/lib/core/api_client.dart
@@ -29,16 +29,19 @@ class ApiClient {
     dioClient.interceptors.add(
       dio.InterceptorsWrapper(
         onRequest: (options, handler) async {
-          if (options.path == refreshPath) return handler.next(options);
+          debugPrint(
+              "➡️ ${options.method} ${options.uri} path=${options.path}");
+
+          if (options.path == refreshPath) {
+            return handler.next(options);
+          }
 
           final token = await appSecureStorage.read(key: "jwt");
           if (token != null && token.isNotEmpty) {
             options.headers["Authorization"] = "Bearer $token";
           }
 
-          debugPrint(
-              "➡️ ${options.method} ${options.path} auth=${options.headers["Authorization"]}");
-
+          debugPrint("   auth=${options.headers["Authorization"]}");
           return handler.next(options);
         },
         onError: (e, handler) async {

--- a/healthy_scanner/lib/core/api_client.dart
+++ b/healthy_scanner/lib/core/api_client.dart
@@ -15,7 +15,7 @@ class ApiClient {
     dio.BaseOptions(
       baseUrl: baseUrl,
       connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 20),
       headers: {"Content-Type": "application/json"},
     ),
   );

--- a/healthy_scanner/lib/core/api_client.dart
+++ b/healthy_scanner/lib/core/api_client.dart
@@ -15,7 +15,7 @@ class ApiClient {
     dio.BaseOptions(
       baseUrl: baseUrl,
       connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 30),
+      receiveTimeout: const Duration(seconds: 60),
       headers: {"Content-Type": "application/json"},
     ),
   );

--- a/healthy_scanner/lib/core/api_client.dart
+++ b/healthy_scanner/lib/core/api_client.dart
@@ -15,7 +15,7 @@ class ApiClient {
     dio.BaseOptions(
       baseUrl: baseUrl,
       connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 20),
+      receiveTimeout: const Duration(seconds: 30),
       headers: {"Content-Type": "application/json"},
     ),
   );

--- a/healthy_scanner/lib/core/onboarding_store.dart
+++ b/healthy_scanner/lib/core/onboarding_store.dart
@@ -1,0 +1,22 @@
+import 'package:get_storage/get_storage.dart';
+
+class OnboardingStore {
+  OnboardingStore._();
+  static final _box = GetStorage();
+
+  static String _key(String? userKey) => userKey == null
+      ? 'onboarding_completed'
+      : 'onboarding_completed_$userKey';
+
+  static bool isCompleted({String? userKey}) {
+    return _box.read(_key(userKey)) == true;
+  }
+
+  static Future<void> setCompleted(bool value, {String? userKey}) async {
+    await _box.write(_key(userKey), value);
+  }
+
+  static Future<void> clear({String? userKey}) async {
+    await _box.remove(_key(userKey));
+  }
+}

--- a/healthy_scanner/lib/core/url_resolver.dart
+++ b/healthy_scanner/lib/core/url_resolver.dart
@@ -1,0 +1,12 @@
+class UrlResolver {
+  static String resolve(String baseHost, String raw) {
+    final p = raw.trim();
+    if (p.isEmpty) return p;
+
+    if (p.startsWith('http://') || p.startsWith('https://')) return p;
+
+    final normalizedPath = p.startsWith('static/') ? '/$p' : p;
+
+    return Uri.https(baseHost, normalizedPath).toString();
+  }
+}

--- a/healthy_scanner/lib/data/archive_response.dart
+++ b/healthy_scanner/lib/data/archive_response.dart
@@ -12,6 +12,7 @@ class ScanHistoryResponse {
 }
 
 class ScanHistoryItem {
+  final String scanId;
   final String name;
   final String category;
   final String riskLevel;
@@ -19,6 +20,7 @@ class ScanHistoryItem {
   final String url;
 
   ScanHistoryItem({
+    required this.scanId,
     required this.name,
     required this.category,
     required this.riskLevel,
@@ -27,7 +29,11 @@ class ScanHistoryItem {
   });
 
   factory ScanHistoryItem.fromJson(Map<String, dynamic> json) {
+    final scanId =
+        (json['scanID'] ?? json['scanId'] ?? json['scan_id'] ?? '').toString();
+
     return ScanHistoryItem(
+      scanId: scanId,
       name: json['name'] ?? '',
       category: json['category'] ?? '',
       riskLevel: json['riskLevel'] ?? 'green',

--- a/healthy_scanner/lib/data/home_response.dart
+++ b/healthy_scanner/lib/data/home_response.dart
@@ -20,6 +20,7 @@ class HomeResponse {
 }
 
 class ScanItem {
+  final String scanId;
   final String name;
   final String category;
   final TrafficLightState riskLevel;
@@ -27,6 +28,7 @@ class ScanItem {
   final String url;
 
   ScanItem({
+    required this.scanId,
     required this.name,
     required this.category,
     required this.riskLevel,
@@ -39,7 +41,12 @@ class ScanItem {
     final rawCategory = json['category'] as String?;
     final level = (json['riskLevel'] ?? 'green').toString().toLowerCase();
 
+    final scanId = (json['scanID'] ?? json['scan_id'] ?? json['scanId'] ?? '')
+        .toString()
+        .trim();
+
     return ScanItem(
+      scanId: scanId,
       name: (rawName == null || rawName.trim().isEmpty)
           ? '식품${index != null ? ' ${index + 1}' : ''}'
           : rawName,

--- a/healthy_scanner/lib/data/scan_api.dart
+++ b/healthy_scanner/lib/data/scan_api.dart
@@ -3,6 +3,7 @@ import 'package:uuid/uuid.dart';
 import 'package:dio/dio.dart' as dio;
 import 'package:get/get.dart' hide Response, FormData;
 import 'package:healthy_scanner/controller/auth_controller.dart';
+import 'package:healthy_scanner/data/scan_history_detail_response.dart';
 
 class ScanAnalyzeResponse {
   final String scanId;
@@ -204,5 +205,67 @@ class ScanApi {
     }
 
     return ScanAnalyzeResponse.fromJson((data).cast<String, dynamic>());
+  }
+
+  Future<ScanHistoryDetailResponse> getScanHistoryDetails({
+    required String scanId,
+  }) async {
+    final requestId = _uuid.v4();
+
+    debugPrint(
+        '➡️ [ScanHistoryDetails API] GET /v1/scan-history/$scanId/details');
+    debugPrint('🧾 requestId: $requestId');
+
+    try {
+      final res = await _dio.get(
+        '/v1/scan-history/$scanId/details',
+        options: dio.Options(
+          headers: {
+            'Accept': 'application/json',
+            'X-Request-ID': requestId,
+          },
+        ),
+      );
+
+      debugPrint('✅ [ScanHistoryDetails API] success');
+      debugPrint('🔍 status: ${res.statusCode}');
+      debugPrint('🔍 headers: ${res.headers}');
+      debugPrint('🔍 data runtimeType: ${res.data.runtimeType}');
+      debugPrint('🔍 raw body: ${res.data}');
+
+      if (res.statusCode != 200) {
+        throw dio.DioException(
+          requestOptions: res.requestOptions,
+          response: res,
+          type: dio.DioExceptionType.badResponse,
+          message: 'GET details failed: ${res.statusCode}',
+        );
+      }
+
+      final data = res.data;
+
+      if (data is! Map) {
+        throw Exception('Unexpected response body: $data');
+      }
+
+      debugPrint('🧩 [ScanHistoryDetails API] keys: ${(data).keys.toList()}');
+
+      final parsed = ScanHistoryDetailResponse.fromJson(
+        (data).cast<String, dynamic>(),
+      );
+
+      debugPrint('✅ [ScanHistoryDetails API] parsed ok: $parsed');
+
+      return parsed;
+    } on dio.DioException catch (e) {
+      debugPrint('❌ [ScanHistoryDetails API] failed');
+      debugPrint('🧾 requestId: $requestId');
+      debugPrint('🔍 status: ${e.response?.statusCode}');
+      debugPrint('🔍 data runtimeType: ${e.response?.data.runtimeType}');
+      debugPrint('🔍 data: ${e.response?.data}');
+      debugPrint('🔍 headers: ${e.response?.headers}');
+      debugPrint('🔍 type: ${e.type}');
+      rethrow;
+    }
   }
 }

--- a/healthy_scanner/lib/data/scan_history_detail_response.dart
+++ b/healthy_scanner/lib/data/scan_history_detail_response.dart
@@ -1,0 +1,215 @@
+class ScanHistoryDetailResponse {
+  final ProductPart product;
+  final ScanPart scan;
+  final NutritionPart? nutrition;
+  final IngredientPart? ingredient;
+
+  ScanHistoryDetailResponse({
+    required this.product,
+    required this.scan,
+    required this.nutrition,
+    required this.ingredient,
+  });
+
+  factory ScanHistoryDetailResponse.fromJson(Map<String, dynamic> json) {
+    return ScanHistoryDetailResponse(
+      product: ProductPart.fromJson(
+          (json['product'] as Map).cast<String, dynamic>()),
+      scan: ScanPart.fromJson((json['scan'] as Map).cast<String, dynamic>()),
+      nutrition: (json['nutrition'] == null)
+          ? null
+          : NutritionPart.fromJson(
+              (json['nutrition'] as Map).cast<String, dynamic>()),
+      ingredient: (json['ingredient'] == null)
+          ? null
+          : IngredientPart.fromJson(
+              (json['ingredient'] as Map).cast<String, dynamic>()),
+    );
+  }
+}
+
+class ProductPart {
+  final String name;
+  final String category;
+  final String imageUrl;
+
+  ProductPart(
+      {required this.name, required this.category, required this.imageUrl});
+
+  factory ProductPart.fromJson(Map<String, dynamic> json) {
+    return ProductPart(
+      name: (json['name'] ?? '').toString(),
+      category: (json['category'] ?? '').toString(),
+      imageUrl: (json['image_url'] ?? '').toString(),
+    );
+  }
+}
+
+class ScanPart {
+  final String summary;
+  final int score;
+  final ScanReports reports;
+  final List<CautionFactor> cautionFactors;
+
+  ScanPart({
+    required this.summary,
+    required this.score,
+    required this.reports,
+    required this.cautionFactors,
+  });
+
+  factory ScanPart.fromJson(Map<String, dynamic> json) {
+    final cf = (json['caution_factors'] as List? ?? [])
+        .whereType<Map>()
+        .map((e) => CautionFactor.fromJson(e.cast<String, dynamic>()))
+        .toList();
+
+    return ScanPart(
+      summary: (json['summary'] ?? '').toString(),
+      score: (json['score'] is int)
+          ? (json['score'] as int)
+          : int.tryParse('${json['score']}') ?? 0,
+      reports: ScanReports.fromJson(
+          (json['reports'] as Map? ?? {}).cast<String, dynamic>()),
+      cautionFactors: cf,
+    );
+  }
+}
+
+class ScanReports {
+  final ReportBlock? allergies;
+  final ReportBlock? condition;
+  final List<AlternativeReport> alternatives;
+  final ReportBlock? vegan;
+
+  ScanReports({
+    required this.allergies,
+    required this.condition,
+    required this.alternatives,
+    required this.vegan,
+  });
+
+  factory ScanReports.fromJson(Map<String, dynamic> json) {
+    final alt = (json['alternatives'] as List? ?? [])
+        .whereType<Map>()
+        .map((e) => AlternativeReport.fromJson(e.cast<String, dynamic>()))
+        .toList();
+
+    return ScanReports(
+      allergies: (json['allergies'] == null)
+          ? null
+          : ReportBlock.fromJson(
+              (json['allergies'] as Map).cast<String, dynamic>()),
+      condition: (json['condition'] == null)
+          ? null
+          : ReportBlock.fromJson(
+              (json['condition'] as Map).cast<String, dynamic>()),
+      alternatives: alt,
+      vegan: (json['vegan'] == null)
+          ? null
+          : ReportBlock.fromJson(
+              (json['vegan'] as Map).cast<String, dynamic>()),
+    );
+  }
+}
+
+class ReportBlock {
+  final String briefReport;
+  final String face; // "NO" | "NOT_BAD" | "GOOD"
+  final String report;
+
+  ReportBlock(
+      {required this.briefReport, required this.face, required this.report});
+
+  factory ReportBlock.fromJson(Map<String, dynamic> json) {
+    return ReportBlock(
+      briefReport: (json['brief_report'] ?? '').toString(),
+      face: (json['face'] ?? '').toString(),
+      report: (json['report'] ?? '').toString(),
+    );
+  }
+}
+
+class AlternativeReport {
+  final String briefReport;
+  final String face;
+  final String report;
+
+  AlternativeReport(
+      {required this.briefReport, required this.face, required this.report});
+
+  factory AlternativeReport.fromJson(Map<String, dynamic> json) {
+    return AlternativeReport(
+      briefReport: (json['brief_report'] ?? '').toString(),
+      face: (json['face'] ?? '').toString(),
+      report: (json['report'] ?? '').toString(),
+    );
+  }
+}
+
+class CautionFactor {
+  final String factor;
+  final String evaluation; // "NO" | "CAUTION" | "OK"
+
+  CautionFactor({required this.factor, required this.evaluation});
+
+  factory CautionFactor.fromJson(Map<String, dynamic> json) {
+    return CautionFactor(
+      factor: (json['factor'] ?? '').toString(),
+      evaluation: (json['evaluation'] ?? '').toString(),
+    );
+  }
+}
+
+class NutritionPart {
+  final double? carbsG;
+  final double? proteinG;
+  final double? sodiumMg;
+  final double? sugarG;
+  final double? fatG;
+  final double? transFatG;
+  final double? satFatG;
+  final double? cholesterolMg;
+  final double? calories;
+  final double? perServingGrams;
+
+  NutritionPart({
+    this.carbsG,
+    this.proteinG,
+    this.sodiumMg,
+    this.sugarG,
+    this.fatG,
+    this.transFatG,
+    this.satFatG,
+    this.cholesterolMg,
+    this.calories,
+    this.perServingGrams,
+  });
+
+  static double? _d(dynamic v) =>
+      (v == null) ? null : (v is num ? v.toDouble() : double.tryParse('$v'));
+
+  factory NutritionPart.fromJson(Map<String, dynamic> json) {
+    return NutritionPart(
+      carbsG: _d(json['carbs_g']),
+      proteinG: _d(json['protein_g']),
+      sodiumMg: _d(json['sodium_mg']),
+      sugarG: _d(json['sugar_g']),
+      fatG: _d(json['fat_g']),
+      transFatG: _d(json['trans_fat_g']),
+      satFatG: _d(json['sat_fat_g']),
+      cholesterolMg: _d(json['cholesterol_mg']),
+      calories: _d(json['calories']),
+      perServingGrams: _d(json['per_serving_grams']),
+    );
+  }
+}
+
+class IngredientPart {
+  final String text;
+  IngredientPart({required this.text});
+
+  factory IngredientPart.fromJson(Map<String, dynamic> json) {
+    return IngredientPart(text: (json['text'] ?? '').toString());
+  }
+}

--- a/healthy_scanner/lib/main.dart
+++ b/healthy_scanner/lib/main.dart
@@ -25,10 +25,6 @@ void main() async {
     ApiService(baseUrl: ApiClient.baseUrl),
     permanent: true,
   );
-  Get.put(
-    MyPageController(Get.find<ApiService>()),
-    permanent: true,
-  );
   Get.put(HomeController(HomeApi(baseUrl: 'https://healthy-scanner.com')));
 
   runApp(const MyApp());

--- a/healthy_scanner/lib/main.dart
+++ b/healthy_scanner/lib/main.dart
@@ -5,7 +5,6 @@ import 'controller/navigation_controller.dart';
 import 'controller/scan_controller.dart';
 import 'controller/auth_controller.dart';
 import 'controller/home_controller.dart';
-import 'controller/mypage_controller.dart';
 import 'data/api_service.dart';
 import 'data/home_api.dart';
 import 'core/app_secure_storage.dart';

--- a/healthy_scanner/lib/main.dart
+++ b/healthy_scanner/lib/main.dart
@@ -9,11 +9,13 @@ import 'data/api_service.dart';
 import 'data/home_api.dart';
 import 'core/app_secure_storage.dart';
 import 'core/api_client.dart';
+import 'package:get_storage/get_storage.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   AppRoutes.validateRoutes();
   await migrateAndCleanupSecureStorage();
+  await GetStorage.init();
 
   ApiClient.setupInterceptors();
 

--- a/healthy_scanner/lib/routes/app_routes.dart
+++ b/healthy_scanner/lib/routes/app_routes.dart
@@ -2,6 +2,8 @@
 import 'package:get/get.dart';
 // import '../controller/navigation_controller.dart';
 import '../controller/scan_waiting_controller.dart';
+import '../controller/mypage_controller.dart';
+import 'package:healthy_scanner/data/api_service.dart';
 
 // [view import]
 import '../view/splash/splash_view.dart';
@@ -114,7 +116,16 @@ class AppRoutes {
         name: onboardingComplete, page: () => const OnboardingCompleteView()),
 
     // ✅ 마이페이지 편집 화면
-    GetPage(name: myPage, page: () => const MyPageView()),
+    GetPage(
+      name: myPage,
+      page: () => const MyPageView(),
+      binding: BindingsBuilder(() {
+        Get.lazyPut<MyPageController>(
+          () => MyPageController(Get.find<ApiService>()),
+          fenix: true,
+        );
+      }),
+    ),
     GetPage(name: myPageDietEdit, page: () => const MyPageDietEditView()),
     GetPage(name: myPageDiseaseEdit, page: () => const MyPageDiseaseEditView()),
     GetPage(name: myPageAllergyEdit, page: () => const MyPageAllergyEditView()),

--- a/healthy_scanner/lib/routes/app_routes.dart
+++ b/healthy_scanner/lib/routes/app_routes.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 // import '../controller/navigation_controller.dart';
 import '../controller/scan_waiting_controller.dart';
 import '../controller/mypage_controller.dart';
+import '../controller/splash_controller.dart';
 import 'package:healthy_scanner/data/api_service.dart';
 
 // [view import]
@@ -65,7 +66,13 @@ class AppRoutes {
   // 📍 페이지 목록 등록
   // ----------------------
   static final pages = [
-    GetPage(name: splash, page: () => const SplashView()),
+    GetPage(
+      name: AppRoutes.splash,
+      page: () => const SplashView(),
+      binding: BindingsBuilder(() {
+        Get.put(SplashController());
+      }),
+    ),
     GetPage(
         name: loginMain,
         page: () => const LoginMainView(),

--- a/healthy_scanner/lib/view/analysis/analysis_result_view.dart
+++ b/healthy_scanner/lib/view/analysis/analysis_result_view.dart
@@ -35,7 +35,9 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
               // 로딩
               if (result.isLoading.value) {
                 return const Center(
-                  child: CircularProgressIndicator(),
+                  child: CircularProgressIndicator(
+                    color: AppColors.mainRed,
+                  ),
                 );
               }
 

--- a/healthy_scanner/lib/view/analysis/analysis_result_view.dart
+++ b/healthy_scanner/lib/view/analysis/analysis_result_view.dart
@@ -5,6 +5,10 @@ import '../../component/traffic_light.dart';
 import '../../component/food_card.dart';
 import '../../theme/app_colors.dart';
 import '../../theme/app_typography.dart';
+import 'package:healthy_scanner/controller/analysis_result_controller.dart';
+import 'package:healthy_scanner/data/scan_history_detail_response.dart';
+import 'package:healthy_scanner/core/url_resolver.dart';
+import 'package:healthy_scanner/theme/theme_extensions.dart';
 
 class AnalysisResultView extends StatefulWidget {
   const AnalysisResultView({super.key});
@@ -14,10 +18,10 @@ class AnalysisResultView extends StatefulWidget {
 }
 
 class _AnalysisResultViewState extends State<AnalysisResultView> {
-  final controller = Get.find<NavigationController>();
+  final nav = Get.find<NavigationController>();
+  final result = Get.put(AnalysisResultController());
 
   int selectedTab = 0; // 0: 알레르기 / 1: 건강질환 / 2: 식습관 / 3: 대체 식품
-  FoodRecommendation currentState = FoodRecommendation.bad;
 
   @override
   Widget build(BuildContext context) {
@@ -26,74 +30,38 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
       body: SafeArea(
         child: Stack(
           children: [
-            SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(20, 16, 20, 40),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // ✅ 식품 카드
-                  Padding(
-                    padding: const EdgeInsets.only(top: 60, bottom: 16),
-                    child: SizedBox(
-                      width: MediaQuery.of(context).size.width,
-                      child: FoodCard(
-                        title: '칸쵸',
-                        category: '과자 / 초콜릿가공품',
-                        message: '포화지방과 당류가 다소 높고,\n땅콩이 포함되어 있어요.',
-                        imageAsset: 'assets/images/cancho.png',
-                        warningAsset: 'assets/icons/ic_warning.png',
-                        lightState: TrafficLightState.red,
-                        onTap: () {},
-                      ),
-                    ),
-                  ),
+            Obx(() {
+              // 로딩
+              if (result.isLoading.value) {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
 
-                  // ✅ AI 리포트
-                  Text('AI 리포트',
-                      style: AppTextStyles.bodyBold
-                          .copyWith(color: AppColors.staticBlack)),
-                  const SizedBox(height: 10),
-                  _buildAIReport(),
+              // 에러
+              final err = result.error.value;
+              if (err != null) {
+                return _buildError(err);
+              }
 
-                  const SizedBox(height: 28),
+              // 데이터
+              final data = result.detail.value;
+              if (data == null) {
+                return _buildError('데이터가 비어있어요.');
+              }
 
-                  // ✅ 주의 요소
-                  Text('주의 요소',
-                      style: AppTextStyles.bodyBold
-                          .copyWith(color: AppColors.staticBlack)),
-                  const SizedBox(height: 10),
-                  _buildRiskFactors(),
+              final raw = data.product.imageUrl;
+              final imageUrl = UrlResolver.resolve('healthy-scanner.com', raw);
 
-                  const SizedBox(height: 28),
-
-                  // ✅ 세부 영양성분
-                  _buildNutritionFacts(),
-
-                  const SizedBox(height: 32),
-
-                  // ✅ 원재료명
-                  Text('원재료명',
-                      style: AppTextStyles.bodyBold
-                          .copyWith(color: AppColors.staticBlack)),
-                  const SizedBox(height: 8),
-                  Text(
-                    '밀가루(미국산), 설탕, 땅콩, 코코아버터, 탈지분유, 유청분말, 팜유, 정제소금 등',
-                    style: AppTextStyles.footnote1Regular
-                        .copyWith(color: AppColors.charcoleGray, height: 1.5),
-                  ),
-                ],
-              ),
-            ),
+              return _buildContent(context, data, imageUrl);
+            }),
 
             // ✅ 뒤로가기
             Positioned(
               top: 12,
               left: 12,
               child: GestureDetector(
-                // TODO: 뒤로가기 로직 세분화
-                // i) 촬영 이후 첫 분석 시 - 메인 화면 (현재는 ScanCropView로 이동함)
-                // ii) 리포트>날짜 선택 후 재열람 - 캘린더
-                onTap: controller.goBack,
+                onTap: nav.goBack,
                 child: const Icon(
                   Icons.arrow_back_ios_new,
                   color: AppColors.cloudGray,
@@ -107,18 +75,141 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
     );
   }
 
-  // ============================================================
-  // ✅ AI 리포트 (탭 포함)
-  // ============================================================
-  Widget _buildAIReport() {
+  Widget _buildError(String message) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              "정보를 불러올 수 없어요",
+              style: context.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: result.fetch,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.peachRed,
+                foregroundColor: AppColors.mainRed,
+                textStyle: context.bodyBold,
+              ),
+              child: const Text('다시 시도하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    ScanHistoryDetailResponse data,
+    String imageUrl,
+  ) {
+    final product = data.product;
+    final scan = data.scan;
+
+    final foodState = _scoreToFoodRecommendation(scan.score);
+    final lightState = _scoreToTrafficLight(scan.score);
+
+    // AI 리포트 탭 데이터 구성
     final labels = ['알레르기', '건강질환', '식습관 유형', '대체 식품'];
     final contents = [
-      '이 제품에는 땅콩, 유제품, 밀 성분이 포함되어 있습니다.\n소량의 혼입만으로도 알레르기 반응이 발생할 수 있습니다.',
-      '심혈관 질환이 있는 분은 포화지방 섭취를 줄이는 것이 좋습니다.\n대체로 낮은 지방 간식을 선택하세요.',
-      '유제품 허용 채식으로 분류됩니다.\n식습관에 맞는 제품인지 확인해보세요.',
-      '견과류나 초콜릿이 없는 대체 간식을 추천드립니다.\n예: 쌀과자, 과일칩, 요거트바 등',
+      _reportText(scan.reports.allergies),
+      _reportText(scan.reports.condition),
+      _reportText(scan.reports.vegan),
+      _alternativesText(scan.reports.alternatives),
     ];
 
+    // 주의 요소 (caution_factors)
+    final cautionList = scan.cautionFactors;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 40),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ✅ 식품 카드
+          Padding(
+            padding: const EdgeInsets.only(top: 60, bottom: 16),
+            child: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: FoodCard(
+                title: product.name.isEmpty ? '식품' : product.name,
+                category: product.category.isEmpty ? '카테고리' : product.category,
+                message: scan.summary.isEmpty ? '분석 요약이 없어요.' : scan.summary,
+                imageAsset: imageUrl,
+                warningAsset: (lightState == TrafficLightState.red)
+                    ? 'assets/icons/ic_warning.png'
+                    : null,
+                lightState: lightState,
+                onTap: () {},
+              ),
+            ),
+          ),
+
+          // ✅ AI 리포트
+          Text(
+            'AI 리포트',
+            style:
+                AppTextStyles.bodyBold.copyWith(color: AppColors.staticBlack),
+          ),
+          const SizedBox(height: 10),
+          _buildAIReport(
+            labels: labels,
+            contents: contents,
+            foodState: foodState,
+            score: scan.score,
+          ),
+
+          const SizedBox(height: 28),
+
+          // ✅ 주의 요소 (API)
+          Text(
+            '주의 요소',
+            style:
+                AppTextStyles.bodyBold.copyWith(color: AppColors.staticBlack),
+          ),
+          const SizedBox(height: 10),
+          _buildRiskFactorsFromApi(cautionList),
+
+          const SizedBox(height: 28),
+
+          // ✅ 세부 영양성분 (API)
+          if (data.nutrition != null)
+            _buildNutritionFactsFromApi(data.nutrition!),
+
+          const SizedBox(height: 32),
+
+          // ✅ 원재료명 (API)
+          Text(
+            '원재료명',
+            style:
+                AppTextStyles.bodyBold.copyWith(color: AppColors.staticBlack),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            (data.ingredient?.text.trim().isNotEmpty == true)
+                ? data.ingredient!.text
+                : '원재료 정보가 없어요.',
+            style: AppTextStyles.footnote1Regular
+                .copyWith(color: AppColors.charcoleGray, height: 1.5),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ============================================================
+  // ✅ AI 리포트 (탭 포함) - API 바인딩 버전
+  // ============================================================
+  Widget _buildAIReport({
+    required List<String> labels,
+    required List<String> contents,
+    required FoodRecommendation foodState,
+    required int score,
+  }) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(18),
@@ -136,8 +227,9 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildSummaryBox(currentState),
+          _buildSummaryBox(foodState, score),
           const SizedBox(height: 20),
+
           // 🔹 탭 버튼
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
@@ -169,6 +261,7 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
             ),
           ),
           const SizedBox(height: 16),
+
           Text(
             contents[selectedTab],
             style: AppTextStyles.footnote1Regular
@@ -180,9 +273,9 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
   }
 
   // ============================================================
-  // ✅ 총평 박스
+  // ✅ 총평 박스 (점수 기반)
   // ============================================================
-  Widget _buildSummaryBox(FoodRecommendation state) {
+  Widget _buildSummaryBox(FoodRecommendation state, int score) {
     late Color bgColor;
     late Color iconColor;
     late IconData icon;
@@ -193,19 +286,19 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
         bgColor = AppColors.mainRed;
         iconColor = Colors.white;
         icon = Icons.sentiment_very_dissatisfied_rounded;
-        message = '땅콩 알레르기와 심혈관 질환이 있는 분께는 비추천드립니다.\n안전한 대체 간식을 선택하시길 권장드립니다.';
+        message = '점수 $score점\n섭취를 추천드리지 않아요.';
         break;
       case FoodRecommendation.caution:
         bgColor = AppColors.kakaoYellow;
         iconColor = AppColors.staticBlack;
         icon = Icons.sentiment_neutral_rounded;
-        message = '당류가 다소 높지만, 적정량 섭취 시 괜찮은 간식입니다.\n섭취량에 주의하세요.';
+        message = '점수 $score점\n섭취량을 조절하여 섭취하세요.';
         break;
       case FoodRecommendation.good:
         bgColor = AppColors.mainGreen;
         iconColor = Colors.white;
         icon = Icons.sentiment_satisfied_alt_rounded;
-        message = '영양 성분이 균형 잡혀 있어 추천드립니다!';
+        message = '점수 $score점\n추천드릴만한 좋은 식품이에요.';
         break;
     }
 
@@ -236,9 +329,32 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
   }
 
   // ============================================================
-  // ✅ 주의 요소
+  // ✅ 주의 요소 (API: caution_factors)
   // ============================================================
-  Widget _buildRiskFactors() {
+  Widget _buildRiskFactorsFromApi(List<CautionFactor> items) {
+    if (items.isEmpty) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: AppColors.staticWhite,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.03),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Text(
+          '주의 요소가 없어요.',
+          style: AppTextStyles.footnote1Regular
+              .copyWith(color: AppColors.charcoleGray),
+        ),
+      );
+    }
+
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
@@ -254,16 +370,19 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
         ],
       ),
       child: Column(
-        children: [
-          _buildRiskRow('유제품 허용 채식', TrafficLightState.yellow,
-              icon: Icons.eco_outlined),
-          const Divider(color: AppColors.softGray, thickness: 1, height: 20),
-          _buildRiskRow('심장질환', TrafficLightState.red,
-              icon: Icons.medical_services_outlined),
-          const Divider(color: AppColors.softGray, thickness: 1, height: 20),
-          _buildRiskRow('땅콩 / 견과류 알레르기', TrafficLightState.yellow,
-              icon: Icons.sentiment_dissatisfied_outlined),
-        ],
+        children: List.generate(items.length, (i) {
+          final it = items[i];
+          final state = _evaluationToTrafficLight(it.evaluation);
+
+          return Column(
+            children: [
+              _buildRiskRow(it.factor.isEmpty ? '주의 요소' : it.factor, state),
+              if (i != items.length - 1)
+                const Divider(
+                    color: AppColors.softGray, thickness: 1, height: 20),
+            ],
+          );
+        }),
       ),
     );
   }
@@ -287,34 +406,40 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
   }
 
   // ============================================================
-  // ✅ 세부 영양성분 (2줄 구조 + Divider + 정렬 개선)
+  // ✅ 세부 영양성분 (API nutrition)
   // ============================================================
-  Widget _buildNutritionFacts() {
+  Widget _buildNutritionFactsFromApi(NutritionPart nutrition) {
+    final perServing = nutrition.perServingGrams;
+    final calories = nutrition.calories;
+
     final nutrients = [
-      Nutrient(
-          name: '탄수화물',
-          value: 27,
-          unit: 'g',
-          daily: 324,
-          baseColor: AppColors.staticBlack),
-      Nutrient(
-          name: '단백질',
-          value: 15,
-          unit: 'g',
-          daily: 55,
-          baseColor: AppColors.staticBlack),
-      Nutrient(
-          name: '나트륨',
-          value: 105,
+      _NutrientVM(name: '탄수화물', value: nutrition.carbsG, unit: 'g', daily: 324),
+      _NutrientVM(name: '단백질', value: nutrition.proteinG, unit: 'g', daily: 55),
+      _NutrientVM(
+          name: '나트륨', value: nutrition.sodiumMg, unit: 'mg', daily: 2000),
+      _NutrientVM(name: '당류', value: nutrition.sugarG, unit: 'g', daily: 50),
+      _NutrientVM(name: '지방', value: nutrition.fatG, unit: 'g', daily: 54),
+      _NutrientVM(
+          name: '트랜스지방', value: nutrition.transFatG, unit: 'g', daily: 2),
+      _NutrientVM(name: '포화지방', value: nutrition.satFatG, unit: 'g', daily: 15),
+      _NutrientVM(
+          name: '콜레스테롤',
+          value: nutrition.cholesterolMg,
           unit: 'mg',
-          daily: 2000,
-          baseColor: AppColors.staticBlack),
-      Nutrient(name: '당류', value: 15, unit: 'g', daily: 50),
-      Nutrient(name: '지방', value: 9, unit: 'g', daily: 54),
-      Nutrient(name: '트랜스지방', value: 0, unit: 'g', daily: 2),
-      Nutrient(name: '포화지방', value: 5, unit: 'g', daily: 15),
-      Nutrient(name: '콜레스테롤', value: 2, unit: 'mg', daily: 300),
+          daily: 300),
     ];
+
+    String servingText;
+    if (perServing != null && calories != null) {
+      servingText =
+          '${perServing.toStringAsFixed(0)}g / ${calories.toStringAsFixed(0)}kcal';
+    } else if (perServing != null) {
+      servingText = '${perServing.toStringAsFixed(0)}g';
+    } else if (calories != null) {
+      servingText = '${calories.toStringAsFixed(0)}kcal';
+    } else {
+      servingText = '';
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -322,12 +447,17 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text('세부 영양성분',
-                style: AppTextStyles.bodyBold
-                    .copyWith(color: AppColors.staticBlack)),
-            Text('40g / 200kcal',
+            Text(
+              '세부 영양성분',
+              style:
+                  AppTextStyles.bodyBold.copyWith(color: AppColors.staticBlack),
+            ),
+            if (servingText.isNotEmpty)
+              Text(
+                servingText,
                 style: AppTextStyles.caption1Regular
-                    .copyWith(color: AppColors.brownGray)),
+                    .copyWith(color: AppColors.brownGray),
+              ),
           ],
         ),
         const SizedBox(height: 10),
@@ -348,29 +478,31 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
           child: Column(
             children: List.generate(nutrients.length, (i) {
               final n = nutrients[i];
-              final percent =
-                  (n.value / n.daily * 100).clamp(0, 100).toDouble();
+
+              final value = n.value ?? 0;
+              final percent = (n.daily <= 0)
+                  ? 0.0
+                  : ((value / n.daily) * 100).clamp(0, 100).toDouble();
+
               final isOver = percent > 20;
-              final barColor = (n.baseColor != null)
-                  ? n.baseColor!
-                  : isOver
-                      ? AppColors.mainRed
-                      : AppColors.mainGreen;
+              final barColor = isOver ? AppColors.mainRed : AppColors.mainGreen;
 
               return Column(
                 children: [
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // 기준치 바
+                      // 기준치 바(회색) + %
                       Row(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           SizedBox(
                             width: 70,
-                            child: Text(n.name,
-                                style: AppTextStyles.footnote1Medium
-                                    .copyWith(color: AppColors.staticBlack)),
+                            child: Text(
+                              n.name,
+                              style: AppTextStyles.footnote1Medium
+                                  .copyWith(color: AppColors.staticBlack),
+                            ),
                           ),
                           Expanded(
                             child: Container(
@@ -391,7 +523,7 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
                       ),
                       const SizedBox(height: 6),
 
-                      // 실제 함유량 바
+                      // 실제 함유량 바 + 값
                       Row(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
@@ -413,10 +545,13 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
                             ),
                           ),
                           const SizedBox(width: 8),
-                          Text('${n.value}${n.unit}',
-                              style: AppTextStyles.footnote1Medium.copyWith(
-                                  color: barColor,
-                                  fontWeight: FontWeight.bold)),
+                          Text(
+                            n.value == null ? '-' : '${_fmt(n.value)}${n.unit}',
+                            style: AppTextStyles.footnote1Medium.copyWith(
+                              color: barColor,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
                         ],
                       ),
                     ],
@@ -425,7 +560,10 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
                     const Padding(
                       padding: EdgeInsets.symmetric(vertical: 12),
                       child: Divider(
-                          color: AppColors.softGray, thickness: 1, height: 1),
+                        color: AppColors.softGray,
+                        thickness: 1,
+                        height: 1,
+                      ),
                     ),
                 ],
               );
@@ -435,25 +573,79 @@ class _AnalysisResultViewState extends State<AnalysisResultView> {
       ],
     );
   }
+
+  // ============================================================
+  // helpers
+  // ============================================================
+  FoodRecommendation _scoreToFoodRecommendation(int score) {
+    if (score < 35) return FoodRecommendation.bad;
+    if (score < 70) return FoodRecommendation.caution;
+    return FoodRecommendation.good;
+  }
+
+  TrafficLightState _scoreToTrafficLight(int score) {
+    if (score < 35) return TrafficLightState.red;
+    if (score < 70) return TrafficLightState.yellow;
+    return TrafficLightState.green;
+  }
+
+  TrafficLightState _evaluationToTrafficLight(String evaluation) {
+    switch (evaluation) {
+      case 'NO':
+        return TrafficLightState.red;
+      case 'OK':
+        return TrafficLightState.green;
+      case 'CAUTION':
+      default:
+        return TrafficLightState.yellow;
+    }
+  }
+
+  String _reportText(ReportBlock? block) {
+    if (block == null) return '분석된 리포트가 없어요.';
+    final brief = block.briefReport.trim();
+    final report = block.report.trim();
+
+    if (brief.isEmpty && report.isEmpty) return '분석된 리포트가 없어요.';
+    if (brief.isEmpty) return report;
+    if (report.isEmpty) return brief;
+
+    // brief_report는 보여주지 않도록 삭제
+    return report;
+  }
+
+  String _alternativesText(List<AlternativeReport> list) {
+    if (list.isEmpty) return '추천드릴만한 대체 식품이 없어요.';
+
+    return list.map((e) {
+      final brief = e.briefReport.trim();
+      final report = e.report.trim();
+      if (brief.isEmpty) return report.isEmpty ? '-' : report;
+      if (report.isEmpty) return brief;
+      return '• $brief\n$report';
+    }).join('\n\n');
+  }
+
+  String _fmt(double? v) {
+    if (v == null) return '-';
+    final s = v.toString();
+    if (s.endsWith('.0')) return v.toStringAsFixed(0);
+    return v.toStringAsFixed(1);
+  }
 }
 
-// ============================================================
-// ENUM & MODEL
-// ============================================================
 enum FoodRecommendation { bad, caution, good }
 
-class Nutrient {
+class _NutrientVM {
   final String name;
-  final double value;
+  final double? value;
   final String unit;
   final double daily;
-  final Color? baseColor;
 
-  Nutrient({
+  _NutrientVM({
     required this.name,
     required this.value,
     required this.unit,
     required this.daily,
-    this.baseColor,
   });
 }

--- a/healthy_scanner/lib/view/archive/archive_list.dart
+++ b/healthy_scanner/lib/view/archive/archive_list.dart
@@ -5,12 +5,15 @@ import 'package:healthy_scanner/theme/app_colors.dart';
 import 'package:healthy_scanner/component/food_card.dart';
 import 'package:healthy_scanner/controller/archive_controller.dart';
 import 'package:healthy_scanner/component/traffic_light.dart';
+import 'package:healthy_scanner/controller/navigation_controller.dart';
 
 class ArchiveListView extends StatelessWidget {
   final DateTime selectedDate;
-  const ArchiveListView({super.key, required this.selectedDate});
+  ArchiveListView({super.key, required this.selectedDate});
 
   String _prettyKoreanDate(DateTime d) => '${d.year}년 ${d.month}월 ${d.day}일';
+
+  final NavigationController _nav = Get.find<NavigationController>();
 
   @override
   Widget build(BuildContext context) {
@@ -120,7 +123,13 @@ class ArchiveListView extends StatelessWidget {
                       imageAsset: it.url,
                       warningAsset: 'assets/icons/ic_warning.png',
                       lightState: riskToState(it.riskLevel),
-                      onTap: () {},
+                      onTap: () {
+                        final scanId = it.scanId;
+                        debugPrint('🖱️ [Archive] tapped scanId=$scanId');
+                        if (scanId.isEmpty) return;
+
+                        _nav.goToAnalysisResult(scanId: scanId);
+                      },
                     );
                   },
                 );

--- a/healthy_scanner/lib/view/home/home.dart
+++ b/healthy_scanner/lib/view/home/home.dart
@@ -10,7 +10,9 @@ import 'package:healthy_scanner/view/home/home_progress_bar.dart';
 import 'package:healthy_scanner/view/home/home_curved_clipper.dart';
 
 class HomeView extends StatelessWidget {
-  const HomeView({super.key});
+  HomeView({super.key});
+
+  final NavigationController _nav = Get.find<NavigationController>();
 
   @override
   Widget build(BuildContext context) {
@@ -183,7 +185,12 @@ class HomeView extends StatelessWidget {
                             imageAsset: items[0].url,
                             warningAsset: 'assets/icons/ic_warning.png',
                             lightState: items[0].riskLevel,
-                            onTap: () {},
+                            onTap: () {
+                              final scanId = items[0].scanId;
+                              debugPrint("Tapped! $scanId");
+                              if (scanId.isEmpty) return;
+                              _nav.goToAnalysisResult(scanId: scanId);
+                            },
                           ),
                           const SizedBox(height: 15),
                           if (items.length > 1)
@@ -194,7 +201,11 @@ class HomeView extends StatelessWidget {
                               imageAsset: items[1].url,
                               warningAsset: 'assets/icons/ic_warning.png',
                               lightState: items[1].riskLevel,
-                              onTap: () {},
+                              onTap: () {
+                                final scanId = items[1].scanId;
+                                if (scanId.isEmpty) return;
+                                _nav.goToAnalysisResult(scanId: scanId);
+                              },
                             ),
                         ],
                       ],

--- a/healthy_scanner/lib/view/home/home.dart
+++ b/healthy_scanner/lib/view/home/home.dart
@@ -30,6 +30,8 @@ class HomeView extends StatelessWidget {
       extendBody: true,
       body: Obx(() {
         final score = home.todayScore.value;
+        final displayScore = score < 0 ? '-' : score.toString();
+        final progressValue = score < 0 ? 0.0 : (score / 100.0).clamp(0.0, 1.0);
         final items = home.scanItems;
 
         return Column(
@@ -69,7 +71,7 @@ class HomeView extends StatelessWidget {
                               alignment: Alignment.center,
                               children: [
                                 SemiCircularProgress(
-                                  value: (score / 100.0).clamp(0.0, 1.0),
+                                  value: progressValue,
                                   size: 224,
                                   thickness: 12,
                                   offsetY: 50,
@@ -80,7 +82,7 @@ class HomeView extends StatelessWidget {
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
                                     Text(
-                                      '$score',
+                                      displayScore,
                                       style: context.largeTitle.copyWith(
                                           color: AppColors.staticWhite),
                                     ),

--- a/healthy_scanner/lib/view/login/kakao_login_webview.dart
+++ b/healthy_scanner/lib/view/login/kakao_login_webview.dart
@@ -66,6 +66,7 @@ class _KakaoLoginWebViewState extends State<KakaoLoginWebView> {
 
       final appAccessToken = data["app_access_token"] as String?;
       final appRefreshToken = data["app_refresh_token"] as String?;
+      final userId = data["user_id"]?.toString();
 
       final kakaoAccessToken = data["kakao_access_token"] as String?;
       final kakaoRefreshToken = data["kakao_refresh_token"] as String?;
@@ -76,7 +77,9 @@ class _KakaoLoginWebViewState extends State<KakaoLoginWebView> {
       if (appAccessToken != null &&
           appRefreshToken != null &&
           kakaoAccessToken != null &&
-          kakaoRefreshToken != null) {
+          kakaoRefreshToken != null &&
+          userId != null &&
+          userId.isNotEmpty) {
         await auth.onKakaoLoginCompleted(
           appAccessToken: appAccessToken,
           appRefreshToken: appRefreshToken,
@@ -85,6 +88,7 @@ class _KakaoLoginWebViewState extends State<KakaoLoginWebView> {
           tokenType: tokenType,
           expiresIn: expiresIn,
           refreshExpiresIn: refreshExpiresIn,
+          userId: userId,
         );
       } else {
         debugPrint("⚠️ Missing required fields in login response: $data");

--- a/healthy_scanner/lib/view/login/login_main_view.dart
+++ b/healthy_scanner/lib/view/login/login_main_view.dart
@@ -49,7 +49,6 @@ class LoginMainView extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   /// ✅ 카카오 로그인 버튼
-                  /// 현재는 로그인 성공 로직 없이 바로 홈으로 이동함.
                   SocialLoginButton(
                     label: '카카오로 로그인',
                     background: AppColors.kakaoYellow,
@@ -71,47 +70,25 @@ class LoginMainView extends StatelessWidget {
                   ),
                   const SizedBox(height: 7),
 
-                  /// ✅ 네이버 로그인 버튼
-                  /// 현재는 카카오 버튼과 동일하게 홈으로 이동만 수행.
-                  SocialLoginButton(
-                    label: '네이버로 로그인',
-                    background: AppColors.naverGreen,
-                    labelStyle: const TextStyle(
-                      fontFamily: 'NotoSansKR',
-                      fontWeight: FontWeight.w500,
-                      fontSize: 12,
-                      letterSpacing: 0,
-                      wordSpacing: 1.3,
-                    ),
-                    leading: const Image(
-                      image: AssetImage("assets/icons/ic_naver.png"),
-                      width: 29,
-                      height: 29,
-                    ),
-                    onPressed: () {
-                      // TODO: 네이버 로그인 API 연동 예정
-                      nav.goToOnboardingAgree(); // ✅ 임시로 온보딩으로 이동
-                    },
-                  ),
-                  const SizedBox(height: 20),
-
                   /// 문의 링크 텍스트
                   GestureDetector(
                     behavior: HitTestBehavior.opaque,
                     onTap: () {
                       // TODO: 문의 페이지 연결 (예: 이메일, 피드백 폼 등)
-                      // 임시 개발용: 로그인 없이 온보딩으로 연결
-                      nav.goToOnboardingAgree();
                     },
                     child: Padding(
-                      padding: const EdgeInsets.all(6),
+                      padding: const EdgeInsets.all(10),
                       child: Text(
                         '문제가 있나요?',
                         style: context.caption2Regular
                             .copyWith(color: Colors.white),
                       ),
                     ),
-                  )
+                  ),
+
+                  const SizedBox(
+                    height: 30,
+                  ),
                 ],
               ),
             ),
@@ -154,7 +131,7 @@ class SocialLoginButton extends StatelessWidget {
         borderRadius: BorderRadius.circular(7),
         onTap: onPressed,
         child: Container(
-          height: 35,
+          height: 40,
           decoration: BoxDecoration(
             color: background,
             borderRadius: BorderRadius.circular(7),

--- a/healthy_scanner/lib/view/main/main_shell_view.dart
+++ b/healthy_scanner/lib/view/main/main_shell_view.dart
@@ -17,9 +17,9 @@ class MainShellView extends StatefulWidget {
 class _MainShellViewState extends State<MainShellView> {
   int _selectedIndex = 0;
 
-  final List<Widget> _pages = const [
+  final List<Widget> _pages = [
     HomeView(),
-    ArchiveCalendarView(),
+    const ArchiveCalendarView(),
   ];
 
   void _onTabTapped(int index) {

--- a/healthy_scanner/lib/view/mypage/mypage_view.dart
+++ b/healthy_scanner/lib/view/mypage/mypage_view.dart
@@ -209,6 +209,8 @@ class MyPageView extends GetView<MyPageController> {
                                   actions: [
                                     TextButton(
                                       onPressed: () => Get.back(),
+                                      style: TextButton.styleFrom(
+                                          overlayColor: AppColors.cloudGray),
                                       child: Text(
                                         '취소',
                                         style: AppTextStyles.caption1Medium
@@ -222,6 +224,8 @@ class MyPageView extends GetView<MyPageController> {
                                         Get.back();
                                         await auth.withdrawAccount();
                                       },
+                                      style: TextButton.styleFrom(
+                                          overlayColor: AppColors.cloudGray),
                                       child: Text(
                                         '탈퇴',
                                         style: AppTextStyles.caption1Medium

--- a/healthy_scanner/lib/view/mypage/mypage_view.dart
+++ b/healthy_scanner/lib/view/mypage/mypage_view.dart
@@ -82,7 +82,6 @@ class MyPageView extends GetView<MyPageController> {
                       ),
                     ),
                     const SizedBox(height: 8),
-
                     Container(
                       width: double.infinity,
                       padding: const EdgeInsets.all(20),
@@ -129,7 +128,6 @@ class MyPageView extends GetView<MyPageController> {
                       ),
                     ),
                     const SizedBox(height: 24),
-
                     Container(
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       decoration: BoxDecoration(
@@ -158,7 +156,6 @@ class MyPageView extends GetView<MyPageController> {
                       ),
                     ),
                     const SizedBox(height: 24),
-
                     Container(
                       width: double.infinity,
                       decoration: BoxDecoration(
@@ -193,22 +190,45 @@ class MyPageView extends GetView<MyPageController> {
                               Get.dialog(
                                 AlertDialog(
                                   shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12),
+                                    borderRadius: BorderRadius.circular(20),
                                   ),
-                                  title: const Text('계정을 정말 탈퇴하시겠어요?'),
-                                  content:
-                                      const Text('탈퇴 후 데이터는 복구되지 않습니다.'),
+                                  backgroundColor: AppColors.backgroundGray,
+                                  title: Text(
+                                    '정말 탈퇴하시겠어요?',
+                                    style: AppTextStyles.bodyBold.copyWith(
+                                      color: AppColors.staticBlack,
+                                    ),
+                                  ),
+                                  content: Text(
+                                    '탈퇴 후 데이터는 복구되지 않습니다.',
+                                    style:
+                                        AppTextStyles.caption1Medium.copyWith(
+                                      color: AppColors.staticBlack,
+                                    ),
+                                  ),
                                   actions: [
                                     TextButton(
                                       onPressed: () => Get.back(),
-                                      child: const Text('취소'),
+                                      child: Text(
+                                        '취소',
+                                        style: AppTextStyles.caption1Medium
+                                            .copyWith(
+                                          color: AppColors.charcoleGray,
+                                        ),
+                                      ),
                                     ),
                                     TextButton(
                                       onPressed: () async {
                                         Get.back();
                                         await auth.withdrawAccount();
                                       },
-                                      child: const Text('탈퇴'),
+                                      child: Text(
+                                        '탈퇴',
+                                        style: AppTextStyles.caption1Medium
+                                            .copyWith(
+                                          color: AppColors.mainRed,
+                                        ),
+                                      ),
                                     ),
                                   ],
                                 ),

--- a/healthy_scanner/lib/view/splash/splash_view.dart
+++ b/healthy_scanner/lib/view/splash/splash_view.dart
@@ -1,52 +1,10 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:healthy_scanner/routes/app_routes.dart';
 import 'package:healthy_scanner/theme/app_colors.dart';
+import 'package:healthy_scanner/controller/splash_controller.dart';
 
-class SplashView extends StatefulWidget {
-  /// 스플래시 유지 시간
-  final Duration duration;
-
-  /// 다음으로 이동할 화면 (없으면 기본 라우트로 이동)
-  final Widget? next;
-
-  const SplashView({
-    super.key,
-    this.next, // ✅ required 제거
-    this.duration = const Duration(seconds: 2),
-  });
-
-  @override
-  State<SplashView> createState() => _SplashViewState();
-}
-
-class _SplashViewState extends State<SplashView> {
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-
-    // duration 후 다음 화면으로 이동
-    _timer = Timer(widget.duration, () {
-      if (!mounted) return;
-
-      if (widget.next != null) {
-        // ✅ next가 있으면 지정된 화면으로 이동
-        Get.offAll(() => widget.next!);
-      } else {
-        // ✅ next가 없으면 기본적으로 로그인 메인으로 이동
-        Get.offAllNamed(AppRoutes.loginMain);
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
+class SplashView extends GetView<SplashController> {
+  const SplashView({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/healthy_scanner/pubspec.yaml
+++ b/healthy_scanner/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   path_provider: ^2.1.5
   dio: ^5.9.0
   uuid: ^4.5.2
+  get_storage: ^2.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 설명
식품 분석 상세 조회 API를 연결하며, 눈에 보이는 자잘한 에러를 수정 및 개선했습니다.

## 구현 내용
- AnalysisResultView에 API 붙이기 + 주의 요소 한국어로 매핑하기
- 마이페이지 조회 시점 변경 (최초 main 말고 마이페이지 진입 시에만 fetch)
- 회원 탈퇴 팝업 디자인 리팩토링
- 네이버 로그인 버튼 삭제
- 온보딩 완료 시 라우팅 로직 추가

## 고민한 내용
- 마이페이지에 진입할 때마다, 홈에 진입할 때마다 fetch 될 수 있도록 라우팅 로직과 호출 시점을 수정하였습니다.
- 서버에서 주의 요소를 영문으로 내려주고 있었는데, onboarding_constants를 활용하여 한국어로 매핑 진행하였습니다.

## 추후 작업할 내용
- 전반적으로 GPT를 좀 더 괴롭혀서 좋은 결과물을 뽑아내야 할 것 같습니다.
- 서버에서 ingredient와 nutrition을 null로 내려주는 에러가 있어서 AnalysisResultView는 아직 미완입니다.
- 또한 주의 요소가 명세에서 정하지 않은 값(not vegan)으로 내려오고 있어서 백엔드에 점검 요청드렸습니다.
- 마이페이지에서도 totalScanCount를 제외한 모든 값(userName, habit, conditions, allergies)이 null로 내려오고 있어서 백엔드에 버그 수정 요청드렸습니다.
- 전반적으로 아직 미완이지만~ 혹시 작업 이어서 진행하고 싶으실 때 참고하시라고 일단 PR 올립니다.

## 연결된 이슈
- #46
